### PR TITLE
Allow sssd responders to run as socket activated services

### DIFF
--- a/sssd.fc
+++ b/sssd.fc
@@ -3,7 +3,14 @@
 /etc/sssd(/.*)?			gen_context(system_u:object_r:sssd_conf_t,s0)
 
 /usr/sbin/sssd		--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_autofs	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_ifp	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_nss	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_pac	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_pam	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_secrets	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_ssh	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_sudo	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 
 /usr/lib/systemd/system/sssd.*      --      gen_context(system_u:object_r:sssd_unit_file_t,s0)
 

--- a/sssd.te
+++ b/sssd.te
@@ -48,6 +48,9 @@ allow sssd_t self:fifo_file rw_fifo_file_perms;
 allow sssd_t self:key manage_key_perms;
 allow sssd_t self:unix_stream_socket { create_stream_socket_perms connectto };
 
+# Allow sssd_t to execute responders; which has different context now
+allow sssd_t sssd_exec_t:file execute_no_trans;
+
 read_files_pattern(sssd_t, sssd_conf_t, sssd_conf_t)
 list_dirs_pattern(sssd_t, sssd_conf_t, sssd_conf_t)
 
@@ -59,6 +62,10 @@ manage_files_pattern(sssd_t, sssd_var_lib_t, sssd_var_lib_t)
 manage_lnk_files_pattern(sssd_t, sssd_var_lib_t, sssd_var_lib_t)
 manage_sock_files_pattern(sssd_t, sssd_var_lib_t, sssd_var_lib_t)
 files_var_lib_filetrans(sssd_t, sssd_var_lib_t, { file dir })
+
+# Allow systemd to create sockets for socket activated responders
+create_sock_files_pattern(init_t, sssd_var_lib_t, sssd_var_lib_t)
+delete_sock_files_pattern(init_t, sssd_var_lib_t, sssd_var_lib_t)
 
 manage_files_pattern(sssd_t, sssd_var_log_t, sssd_var_log_t)
 logging_log_filetrans(sssd_t, sssd_var_log_t, file)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1416318#c1

Please provide feedback to this trivial solution of RHBZ1416318. All responder should be running with `sssd_t` domain but they do not require all privileges. I have a plan to run responders with different domain  will less privileges.