### PR TITLE
Add support for cups-pdf 3.0.x

### DIFF
--- a/cups.te
+++ b/cups.te
@@ -603,6 +603,7 @@ optional_policy(`
 
 allow cups_pdf_t self:capability { chown fowner fsetid setuid setgid dac_override };
 allow cups_pdf_t self:unix_stream_socket create_stream_socket_perms;
+allow cups_pdf_t cupsd_rw_etc_t:dir search;
 
 append_files_pattern(cups_pdf_t, cupsd_log_t, cupsd_log_t)
 create_files_pattern(cups_pdf_t, cupsd_log_t, cupsd_log_t)


### PR DESCRIPTION
This new release search for PPDs on /etc/cups/ppd directory.

Note: Not sure if the dontaudit attribute is useful for this case or not.