### PR TITLE
sssd-kcm should not run as unconfined_service_t BZ(1447411)

### DIFF
--- a/sssd.fc
+++ b/sssd.fc
@@ -6,6 +6,7 @@
 /usr/libexec/sssd/sssd_autofs	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_ifp	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_nss	--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/libexec/sssd/sssd_kcm	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_pac	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_pam	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_secrets	--	gen_context(system_u:object_r:sssd_exec_t,s0)
@@ -26,3 +27,4 @@
 
 /var/run/sssd.pid	--	gen_context(system_u:object_r:sssd_var_run_t,s0)
 /var/run/secrets.socket		gen_context(system_u:object_r:sssd_var_run_t,s0)
+/var/run/.heim_org.h5l.kcm-socket		gen_context(system_u:object_r:sssd_var_run_t,s0)

--- a/sssd.if
+++ b/sssd.if
@@ -425,6 +425,44 @@ interface(`sssd_dontaudit_stream_connect',`
 	dontaudit $1 sssd_var_lib_t:sock_file { read write };
 ')
 
+########################################
+## <summary>
+##	Connect to sssd over a unix stream socket in /var/run.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sssd_run_stream_connect',`
+	gen_require(`
+		type sssd_t, sssd_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, sssd_var_run_t, sssd_var_run_t, sssd_t)
+')
+
+########################################
+## <summary>
+##	Dontaudit attempts to connect to sssd over a unix stream socket in /var/run.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sssd_dontaudit_run_stream_connect',`
+	gen_require(`
+		type sssd_t, sssd_var_lib_t;
+	')
+
+	dontaudit $1 sssd_t:unix_stream_socket connectto;
+	dontaudit $1 sssd_var_run_t:sock_file { read write };
+')
+
 #######################################
 ## <summary>
 ##     Manage keys for all user domains.

--- a/sssd.te
+++ b/sssd.te
@@ -47,6 +47,7 @@ allow sssd_t self:process { setfscreate setsched sigkill signal getsched setrlim
 allow sssd_t self:fifo_file rw_fifo_file_perms;
 allow sssd_t self:key manage_key_perms;
 allow sssd_t self:unix_stream_socket { create_stream_socket_perms connectto };
+sssd_run_stream_connect(sssd_t)
 
 # Allow sssd_t to execute responders; which has different context now
 allow sssd_t sssd_exec_t:file execute_no_trans;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1447411
https://docs.pagure.org/SSSD.sssd/design_pages/kcm.html

`/var/run/.heim_org.h5l.kcm-socket` will be used by any application which use krb5 as a client. 
I am not sure whether the name of macro `sssd_run_stream_connect` is the best one. But i wanted to distinguish between using unix sockets in `/var/lib/sss/pipes` and `/var/run/`