### PR TITLE
Use stricter fc rules for sssd sockets in /var/run

### DIFF
--- a/sssd.fc
+++ b/sssd.fc
@@ -26,5 +26,5 @@
 /var/log/sssd(/.*)?		gen_context(system_u:object_r:sssd_var_log_t,s0)
 
 /var/run/sssd.pid	--	gen_context(system_u:object_r:sssd_var_run_t,s0)
-/var/run/secrets.socket		gen_context(system_u:object_r:sssd_var_run_t,s0)
-/var/run/.heim_org.h5l.kcm-socket	--  	gen_context(system_u:object_r:sssd_var_run_t,s0)
+/var/run/secrets\.socket	-s	gen_context(system_u:object_r:sssd_var_run_t,s0)
+/var/run/\.heim_org\.h5l\.kcm-socket	-s	gen_context(system_u:object_r:sssd_var_run_t,s0)


### PR DESCRIPTION
* mark them as sockets
* escape dots

sh$ semanage fcontext -l | grep heim_org
/var/run/\.heim_org\.h5l\.kcm-socket socket system_u:object_r:sssd_var_run_t:s0