### PR TITLE
Allow zabbix_t to kill zabbix_script_t processes

### DIFF
--- a/zabbix.te
+++ b/zabbix.te
@@ -254,6 +254,7 @@ domtrans_pattern(zabbix_t, zabbix_script_exec_t, zabbix_script_t)
 allow zabbix_t zabbix_script_exec_t:dir search_dir_perms;
 allow zabbix_t zabbix_script_exec_t:dir read_file_perms;
 allow zabbix_t zabbix_script_exec_t:file ioctl;
+allow zabbix_t zabbix_script_t:process signal;
 
 init_domtrans_script(zabbix_script_t)
 


### PR DESCRIPTION
The zabbix server needs the ability to kill scripts that are running
too long.

See also zabbix bug ZBX-11631

Needs also backporting to F25 and 26.