### PR TITLE
Allow RabbitMQ to use systemd-notify

### DIFF
--- a/rabbitmq.te
+++ b/rabbitmq.te
@@ -39,6 +39,7 @@ allow rabbitmq_t self:capability setuid;
 allow rabbitmq_t self:process { setsched signal signull };
 allow rabbitmq_t self:fifo_file rw_fifo_file_perms;
 allow rabbitmq_t self:tcp_socket { accept listen };
+allow rabbitmq_t self:unix_dgram_socket { connect create getopt setopt write };
 
 manage_dirs_pattern(rabbitmq_t, rabbitmq_var_lib_t, rabbitmq_var_lib_t)
 manage_files_pattern(rabbitmq_t, rabbitmq_var_lib_t, rabbitmq_var_lib_t)
@@ -58,6 +59,8 @@ manage_dirs_pattern(rabbitmq_t, rabbitmq_var_run_t, rabbitmq_var_run_t)
 manage_files_pattern(rabbitmq_t, rabbitmq_var_run_t, rabbitmq_var_run_t)
 manage_lnk_files_pattern(rabbitmq_t, rabbitmq_var_run_t, rabbitmq_var_run_t)
 files_pid_filetrans(rabbitmq_t, rabbitmq_var_run_t, { dir file })
+
+kernel_dgram_send(rabbitmq_t)
 
 kernel_read_system_state(rabbitmq_t)
 kernel_read_fs_sysctls(rabbitmq_t)


### PR DESCRIPTION
This PR explicitly allows RabbitMQ to open and send data to systemd-notify through Unix-socket.

A very similar code was added into ejabberd.te and couchdb.te recently. Maybe we'd better split it off into the optional module? Something like systemd-notify.if. I guess some other apps also require that functionality.
