### PR TITLE
Fix for Snapper file context definitions for home directory. bz(1465729)

### DIFF
--- a/snapper.fc
+++ b/snapper.fc
@@ -12,5 +12,4 @@
 /usr/\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
 /var/\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
 /etc/\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
-/home/\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
-/home/(.*/)?\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
+HOME_ROOT/(.*/)?\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)


### PR DESCRIPTION
Hi, I just wanted to contribute this small fix for Snapper file context definitions. Please, let me know if I should create the PR using a different branch (I branched from _rawhide_). Thanks!

- Removed redundant home rule.
- Replaced literal _/home_ string with _HOME_ROOT_ variable.
- Fixes [BZ-1465729](https://bugzilla.redhat.com/show_bug.cgi?id=1465729) and some of the issues seen on [BZ-1180876](https://bugzilla.redhat.com/show_bug.cgi?id=1180876).

**Small Observation:** right now the definitions for _/mnt_ and _/home_ folders match _.snapshots_ folders at any level of depth (e.g. the current _/mnt_ rule will match _/mnt/L1/L2/.snapshots_ as well as _/mnt/L1/L2/L3/L4/L5/.snapshots_).