### PR TITLE
Allow llpdad send dgram to libvirt

### DIFF
--- a/lldpad.te
+++ b/lldpad.te
@@ -64,3 +64,7 @@ optional_policy(`
 optional_policy(`
     networkmanager_dgram_send(lldpad_t)
 ')
+
+optional_policy(`
+    virt_dgram_send(lldpad_t)
+')

--- a/virt.if
+++ b/virt.if
@@ -1700,3 +1700,22 @@ interface(`virt_dontaudit_read_state',`
 	dontaudit $1 virtd_t:file read_file_perms;
 	dontaudit $1 virtd_t:lnk_file read_lnk_file_perms;
 ')
+
+#######################################
+## <summary>
+##	Send to libvirt with a unix dgram socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_dgram_send',`
+	gen_require(`
+		type virtd_t, virt_var_run_t;
+	')
+
+	files_search_pids($1)
+	dgram_send_pattern($1, virt_var_run_t, virt_var_run_t, virtd_t)
+')


### PR DESCRIPTION
Include the rule `allow lldpad_t virtd_t:unix_dgram_socket sendto;` in selinux-policy.
Bug #1472722 says lldpad needs to send dgram to VDSM/libvirt