### PR TITLE
Allow certmonger_t to systemctl pki_tomcat unit files

### DIFF
--- a/certmonger.te
+++ b/certmonger.te
@@ -144,6 +144,7 @@ optional_policy(`
 optional_policy(`
 	pki_rw_tomcat_cert(certmonger_t)
 	pki_read_tomcat_lib_files(certmonger_t)
+	pki_systemctl_tomcat(certmonger_t)
 ')
 
 optional_policy(`

--- a/pki.if
+++ b/pki.if
@@ -285,3 +285,28 @@ interface(`pki_read_tomcat_lib_files',`
     read_files_pattern($1, pki_tomcat_var_lib_t, pki_tomcat_var_lib_t)
     read_lnk_files_pattern($1, pki_tomcat_var_lib_t, pki_tomcat_var_lib_t)
 ')
+
+
+########################################
+## <summary>
+##  Allow given domain systemctl access on pki_tomcat unit files.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed to transition.
+##  </summary>
+## </param>
+#
+interface(`pki_systemctl_tomcat',`
+    gen_require(`
+        type httpd_t;
+        type pki_tomcat_unit_file_t;
+    ')
+
+    systemd_exec_systemctl($1)
+    init_reload_services($1)
+    allow $1 pki_tomcat_unit_file_t:file read_file_perms;
+    allow $1 pki_tomcat_unit_file_t:service manage_service_perms;
+
+    ps_process_pattern($1, httpd_t)
+')


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1475528

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>