### PR TITLE
Add policy for gcl and the gcl-generated binary for maxima

### DIFF
--- a/gcl.fc
+++ b/gcl.fc
@@ -1,0 +1,2 @@
+/usr/lib(64)?/gcl-[^/]+/unixport/saved_.*    --	gen_context(system_u:object_r:gcl_exec_t,s0)
+/usr/lib(64)?/maxima/[^/]+/binary-gcl/maxima --	gen_context(system_u:object_r:gcl_exec_t,s0)

--- a/gcl.if
+++ b/gcl.if
@@ -1,0 +1,143 @@
+## <summary>policy for gcl</summary>
+
+########################################
+## <summary>
+##	Execute a domain transition to run gcl.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`gcl_domtrans',`
+	gen_require(`
+		type gcl_t;
+		type gcl_exec_t;
+	')
+
+	domtrans_pattern($1,gcl_exec_t,gcl_t)
+')
+
+
+########################################
+## <summary>
+##	Do not audit attempts to read,
+##	gcl tmp files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`gcl_dontaudit_read_tmp_files',`
+	gen_require(`
+		type gcl_tmp_t;
+	')
+
+	dontaudit $1 gcl_tmp_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow domain to read, gcl tmp files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`gcl_read_tmp_files',`
+	gen_require(`
+		type gcl_tmp_t;
+	')
+
+	allow $1 gcl_tmp_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow domain to manage gcl tmp files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`gcl_manage_tmp',`
+	gen_require(`
+		type gcl_tmp_t;
+	')
+
+	manage_dirs_pattern($1,gcl_tmp_t,gcl_tmp_t)
+	manage_files_pattern($1,gcl_tmp_t,gcl_tmp_t)
+	manage_lnk_files_pattern($1,gcl_tmp_t,gcl_tmp_t)
+')
+
+########################################
+## <summary>
+##	Execute gcl in the gcl domain, and
+##	allow the specified role the gcl domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the gcl domain.
+##	</summary>
+## </param>
+## <param name="terminal">
+##	<summary>
+##	The type of the role's terminal.
+##	</summary>
+## </param>
+#
+interface(`gcl_run',`
+	gen_require(`
+		type gcl_t;
+	')
+
+	gcl_domtrans($1)
+	role $2 types gcl_t;
+	dontaudit gcl_t $3:chr_file rw_term_perms;
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an gcl environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed to manage the gcl domain.
+##	</summary>
+## </param>
+## <param name="terminal">
+##	<summary>
+##	The type of the user terminal.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`gcl_admin',`
+	gen_require(`
+		type gcl_t;
+	')
+
+	allow $1 gcl_t:process { ptrace signal_perms getattr };
+	read_files_pattern($1, gcl_t, gcl_t)
+
+	gcl_manage_tmp($1)
+')

--- a/gcl.te
+++ b/gcl.te
@@ -1,0 +1,45 @@
+policy_module(gcl,1.0.1)
+
+########################################
+#
+# Declarations
+#
+
+type gcl_t;
+type gcl_exec_t;
+application_domain(gcl_t, gcl_exec_t)
+role system_r types gcl_t;
+
+########################################
+#
+# gcl local policy
+#
+
+## internal communication is often done using fifo and unix sockets.
+allow gcl_t self:fifo_file rw_file_perms;
+allow gcl_t self:unix_stream_socket create_stream_socket_perms;
+
+libs_use_ld_so(gcl_t)
+libs_use_shared_libs(gcl_t)
+
+miscfiles_read_localization(gcl_t)
+
+## The GCL memory management and executable dumping routines manipulate memory
+## in various (usually forbidden) ways.
+allow gcl_t self:process { execmem execheap };
+
+optional_policy(`
+	unconfined_domain(gcl_t)
+')
+
+optional_policy(`
+	gen_require(`
+		type unconfined_t;
+		type unconfined_devpts_t;
+		type unconfined_tty_device_t;
+		role unconfined_r;
+	')
+
+	gcl_run(unconfined_t, unconfined_r, { unconfined_tty_device_t unconfined_devpts_t })
+	allow gcl_t gcl_exec_t:file execmod;
+')


### PR DESCRIPTION
This just moves the existing policy files for gcl from gcl itself into the system selinux policy.  I am by no means any kind of expert on writing selinux policy, so will gladly accept improvements or fixes.  The hope is that not needing to build and install policy at gcl install time will fix https://bugzilla.redhat.com/show_bug.cgi?id=1435395.