### PR TITLE
dbus: add policy for dbus-broker

### DIFF
--- a/dbus.fc
+++ b/dbus.fc
@@ -9,6 +9,8 @@ ifdef(`distro_redhat',`
 ')
 
 /usr/bin/dbus-daemon(-1)? --	gen_context(system_u:object_r:dbusd_exec_t,s0)
+/usr/bin/dbus-broker	 --	gen_context(system_u:object_r:dbusd_exec_t,s0)
+/usr/bin/dbus-broker-launch --	gen_context(system_u:object_r:dbusd_exec_t,s0)
 
 
 ifdef(`distro_debian',`

--- a/dbus.te
+++ b/dbus.te
@@ -141,6 +141,7 @@ init_use_script_ptys(system_dbusd_t)
 init_domtrans_script(system_dbusd_t)
 init_rw_stream_sockets(system_dbusd_t)
 init_status(system_dbusd_t)
+init_start_system(system_dbusd_t) # needed by dbus-broker
 
 logging_send_audit_msgs(system_dbusd_t)
 logging_send_syslog_msg(system_dbusd_t)


### PR DESCRIPTION
dbus-broker is a drop in replacement for dbus-daemon. It can therefore
mostly simply rely on the existing dbus policy module. However, it also
needs to have its binaries labeled correctly, and it needs permission to
perform the D-Bus method call StartTransientUnit on PID1, which
dbus-daemon did not.

For details see <https://github.com/bus1/dbus-broker/wiki>.

Package submission to rawhide: <https://bugzilla.redhat.com/show_bug.cgi?id=1482202>.
Merge into refpolicy: <https://github.com/TresysTechnology/refpolicy-contrib/pull/64>.