### PR TITLE
networkmanager: allow talking to openvswitch

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -1,4 +1,4 @@
-policy_module(networkmanager, 1.15.2)
+policy_module(networkmanager, 1.15.3)
 
 ########################################
 #
@@ -436,6 +436,10 @@ optional_policy(`
 	openfortivpn_sigkill(NetworkManager_t)
 	openfortivpn_signal(NetworkManager_t)
 	openfortivpn_signull(NetworkManager_t)
+')
+
+optional_policy(`
+	openvswitch_stream_connect(NetworkManager_t)
 ')
 
 ########################################


### PR DESCRIPTION
Necessary for NetworkManager to manager openvswitch bridges, ports and
interfaces.