### PR TITLE
Allow pki_tomcat_t use nsswitch

### DIFF
--- a/pki.te
+++ b/pki.te
@@ -110,7 +110,7 @@ manage_files_pattern(pki_tomcat_t, pki_common_t, pki_common_t)
 can_exec(pki_tomcat_t, pki_common_t)
 init_stream_connect_script(pki_tomcat_t)
 
-auth_read_passwd(pki_tomcat_t)
+auth_use_nsswitch(pki_tomcat_t)
 
 search_dirs_pattern(pki_tomcat_t, pki_log_t, pki_log_t)
 


### PR DESCRIPTION
Partially related to ade89ff23d541a761fce0c4a3e6ba14d00ed9be7

I cannot see AVC on f25 only on f26 (and it's already fixed in f27)