### PR TITLE
Revert "Add rules fixing installing ipa-server-install with SELinux i…

### DIFF
--- a/dirsrv.te
+++ b/dirsrv.te
@@ -162,10 +162,6 @@ optional_policy(`
 	systemd_manage_passwd_run(dirsrv_t)
 ')
 
-optional_policy(`
-    rolekit_read_tmp(dirsrv_t)
-')
-
 ########################################
 #
 # dirsrv-snmp local policy

--- a/rolekit.if
+++ b/rolekit.if
@@ -118,21 +118,3 @@ interface(`rolekit_admin',`
 		systemd_read_fifo_file_passwd_run($1)
 	')
 ')
-
-########################################
-## <summary>
-##	Allow domain to read rolekit tmp files
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`rolekit_read_tmp',`
-	gen_require(`
-		type rolekit_tmp_t;
-	')
-
-    read_files_pattern($1, rolekit_tmp_t, rolekit_tmp_t)
-')


### PR DESCRIPTION
…n Enforcing. BZ(1488404)"

This reverts commit 1e84030553d5c8345344ad2f4e3e04062239c165
without reverting changes in rpm.te

It was but in ipa-server-install script
https://bugzilla.redhat.com/show_bug.cgi?id=1490762