### PR TITLE
Allow virtual machines to access TPM devices. BZ(1492635)

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -890,6 +890,7 @@ dev_rw_qemu(virt_domain)
 dev_rw_inherited_vhost(virt_domain)
 dev_rw_infiniband_dev(virt_domain)
 dev_rw_dri(virt_domain)
+dev_rw_tpm(virt_domain)
 
 domain_use_interactive_fds(virt_domain)
 


### PR DESCRIPTION
QEMU needs read and write access to TPM devices to expose them to guest machines using the pass-through backend.

https://bugzilla.redhat.com/show_bug.cgi?id=1492635