### PR TITLE
Ganesha is an nfs server, It should be running as nfsd_exec_t

### DIFF
--- a/cloudform.fc
+++ b/cloudform.fc
@@ -5,6 +5,7 @@
 /usr/libexec/min-cloud-agent    --  gen_context(system_u:object_r:cloud_init_exec_t,s0)
 /usr/bin/deltacloudd    --	gen_context(system_u:object_r:deltacloudd_exec_t,s0)
 /usr/bin/iwhd           --      gen_context(system_u:object_r:iwhd_exec_t,s0)
+/usr/lib/systemd/system-generators/cloud-init.* gen_context(system_u:object_r:cloud_init_exec_t,s0)
 
 /usr/lib/systemd/system/cloud-config.* --  gen_context(system_u:object_r:cloud_init_unit_file_t,s0)
 
@@ -19,3 +20,4 @@
 /var/log/iwhd\.log.*		--		gen_context(system_u:object_r:iwhd_log_t,s0)
 
 /var/run/iwhd\.pid               --      gen_context(system_u:object_r:iwhd_var_run_t,s0)
+/var/run/cloud-init(/.*)?      gen_context(system_u:object_r:cloud_init_var_run_t,s0)

--- a/cloudform.te
+++ b/cloudform.te
@@ -28,6 +28,9 @@ logging_log_file(deltacloudd_log_t)
 type deltacloudd_var_run_t;
 files_pid_file(deltacloudd_var_run_t)
 
+type cloud_init_var_run_t;
+files_pid_file(cloud_init_var_run_t)
+
 type deltacloudd_tmp_t;
 files_tmp_file(deltacloudd_tmp_t)
 
@@ -67,6 +70,12 @@ miscfiles_read_certs(cloudform_domain)
 allow cloud_init_t self:capability { fowner chown fsetid dac_read_search  };
 
 allow cloud_init_t self:udp_socket create_socket_perms;
+
+manage_files_pattern(cloud_init_t, cloud_init_var_run_t, cloud_init_var_run_t)
+manage_dirs_pattern(cloud_init_t, cloud_init_var_run_t, cloud_init_var_run_t)
+manage_lnk_files_pattern(cloud_init_t, cloud_init_var_run_t, cloud_init_var_run_t)
+files_pid_filetrans(cloud_init_t, cloud_init_var_run_t, { file dir })
+sysnet_filetrans_config_fromdir(cloud_init_t, cloud_init_var_run_t, file, "enabled")
 
 manage_files_pattern(cloud_init_t, cloud_init_tmp_t, cloud_init_tmp_t)
 manage_dirs_pattern(cloud_init_t, cloud_init_tmp_t, cloud_init_tmp_t)

--- a/ganesha.te
+++ b/ganesha.te
@@ -96,9 +96,9 @@ optional_policy(`
 ')
 
 optional_policy(`
-	rpc_manage_nfs_state_data_dir(ganesha_t)
+    rpc_manage_nfs_state_data_dir(ganesha_t)
     rpc_read_nfs_state_data(ganesha_t)
-	rpcbind_stream_connect(ganesha_t)
+    rpcbind_stream_connect(ganesha_t)
 ')
 
 tunable_policy(`ganesha_use_fusefs',`
@@ -106,4 +106,27 @@ tunable_policy(`ganesha_use_fusefs',`
     fs_manage_fusefs_files(ganesha_t)
     fs_read_fusefs_symlinks(ganesha_t)
     fs_getattr_fusefs(ganesha_t)
+')
+
+tunable_policy(`nfs_export_all_rw',`
+	dev_getattr_all_blk_files(ganesha_t)
+	dev_getattr_all_chr_files(ganesha_t)
+
+	fs_manage_noxattr_dirs(ganesha_t)
+	fs_manage_noxattr_fs_files(ganesha_t)
+	files_manage_non_security_dirs(ganesha_t)
+	files_manage_non_security_files(ganesha_t)
+')
+
+tunable_policy(`nfs_export_all_ro',`
+	dev_getattr_all_blk_files(ganesha_t)
+	dev_getattr_all_chr_files(ganesha_t)
+
+	files_getattr_all_pipes(ganesha_t)
+	files_getattr_all_sockets(ganesha_t)
+
+	fs_list_noxattr_fs(ganesha_t)
+	fs_read_noxattr_fs_files(ganesha_t)
+	fs_read_noxattr_fs_symlinks(ganesha_t)
+	files_read_non_security_files(ganesha_t)
 ')


### PR DESCRIPTION
This policy moves the definition of ganesha out of glusterd into rpc.fc
Ganesha should follow the nfs booleans and be labeled correctly.