### PR TITLE
Allow cloud-init to create content in /var/run/cloud-init

### DIFF
--- a/cloudform.fc
+++ b/cloudform.fc
@@ -5,6 +5,7 @@
 /usr/libexec/min-cloud-agent    --  gen_context(system_u:object_r:cloud_init_exec_t,s0)
 /usr/bin/deltacloudd    --	gen_context(system_u:object_r:deltacloudd_exec_t,s0)
 /usr/bin/iwhd           --      gen_context(system_u:object_r:iwhd_exec_t,s0)
+/usr/lib/systemd/system-generators/cloud-init.* gen_context(system_u:object_r:cloud_init_exec_t,s0)
 
 /usr/lib/systemd/system/cloud-config.* --  gen_context(system_u:object_r:cloud_init_unit_file_t,s0)
 

--- a/cloudform.te
+++ b/cloudform.te
@@ -158,6 +158,7 @@ optional_policy(`
     sysnet_domtrans_ifconfig(cloud_init_t)
     sysnet_read_dhcpc_state(cloud_init_t)
     sysnet_dns_name_resolve(cloud_init_t)
+    sysnet_filetrans_cloud_net_conf(cloud_init_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Make sure it is labeled in such a way that other domains can read
it, net_conf_t.

/run/cloud-init/enabled

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>