### PR TITLE
allow certain domains to read /proc/net/unix file

### DIFF
--- a/cyrus.te
+++ b/cyrus.te
@@ -62,6 +62,7 @@ files_pid_filetrans(cyrus_t, cyrus_var_run_t, { file sock_file })
 kernel_read_kernel_sysctls(cyrus_t)
 kernel_read_system_state(cyrus_t)
 kernel_read_all_sysctls(cyrus_t)
+kernel_read_network_state(cyrus_t)
 
 corenet_all_recvfrom_netlabel(cyrus_t)
 corenet_tcp_sendrecv_generic_if(cyrus_t)

--- a/linuxptp.te
+++ b/linuxptp.te
@@ -167,6 +167,8 @@ fs_tmpfs_filetrans(ptp4l_t, timemaster_tmpfs_t, { dir file })
 corenet_udp_bind_generic_node(ptp4l_t)
 corenet_udp_bind_reserved_port(ptp4l_t)
 
+kernel_read_network_state(ptp4l_t)
+
 dev_rw_realtime_clock(ptp4l_t)
 
 logging_send_syslog_msg(ptp4l_t)


### PR DESCRIPTION
Certain confined programs wants to read /proc/net/unix but SELinux denies the access. In case of ptp4l we know that if_nametoindex() causes that.