### PR TITLE
Allow qpid to map files (BZ1519948)

### DIFF
--- a/qpid.te
+++ b/qpid.te
@@ -48,6 +48,7 @@ manage_dirs_pattern(qpidd_t, qpidd_var_lib_t,  qpidd_var_lib_t)
 manage_files_pattern(qpidd_t, qpidd_var_lib_t,  qpidd_var_lib_t)
 manage_lnk_files_pattern(qpidd_t, qpidd_var_lib_t,  qpidd_var_lib_t)
 files_var_lib_filetrans(qpidd_t, qpidd_var_lib_t, { file dir lnk_file })
+allow qpidd_t qpidd_var_lib_t:file map;
 
 manage_dirs_pattern(qpidd_t, qpidd_var_run_t,  qpidd_var_run_t)
 manage_files_pattern(qpidd_t, qpidd_var_run_t,  qpidd_var_run_t)


### PR DESCRIPTION
Currently starting qpidd in f27 fails with
`AVC avc:  denied  { map } for  pid=5077 comm="qpidd" path="/var/lib/qpidd/.qpidd/qls/dat2/__db.001" dev="dm-0" ino=534085 scontext=system_u:system_r:qpidd_t:s0 tcontext=system_u:object_r:qpidd_var_lib_t:s0 tclass=file permissive=0`

audit2allow shows:
```
require {
    type qpidd_var_lib_t;
    type qpidd_t;
    class file map;
}

allow qpidd_t qpidd_var_lib_t:file map;
```