### PR TITLE
rpm: Label rpmdb consistently usr_t on ostree/Atomic systems

### DIFF
--- a/rpm.fc
+++ b/rpm.fc
@@ -30,7 +30,8 @@
 /usr/share/yumex/yumex-yum-backend --	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/share/yumex/yum_childtask\.py --	gen_context(system_u:object_r:rpm_exec_t,s0)
 
-/usr/share/rpm(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
+# These may be hardlinked, and they're not /var, so just use usr_t
+/usr/share/rpm(/.*)?			gen_context(system_u:object_r:usr_t,s0)
 
 ifdef(`distro_redhat', `
 /usr/sbin/bcfg2				--	gen_context(system_u:object_r:rpm_exec_t,s0)


### PR DESCRIPTION
This ensures that hardlinking works.

See https://bugzilla.redhat.com/show_bug.cgi?id=1526191
https://github.com/projectatomic/rpm-ostree/pull/959#issuecomment-325780234
https://github.com/projectatomic/rpm-ostree/pull/1142