### PR TITLE
rpm (ostree): Consistent usr_t labeling for kernel/initrd

### DIFF
--- a/rpm.fc
+++ b/rpm.fc
@@ -67,6 +67,13 @@ ifdef(`distro_redhat', `
 /var/run/yum.*			--	gen_context(system_u:object_r:rpm_var_run_t,s0)
 /var/run/PackageKit(/.*)?		gen_context(system_u:object_r:rpm_var_run_t,s0)
 
+# (rpm-)ostree related stuff
+# https://github.com/ostreedev/ostree/pull/1079
+# https://github.com/projectatomic/rpm-ostree/pull/959#issuecomment-325780234
+/usr/lib/ostree-boot(/.*)?	gen_context(system_u:object_r:usr_t,s0)
+/usr/lib/modules(/.*)/vmlinuz         -- 	gen_context(system_u:object_r:usr_t,s0)
+/usr/lib/modules(/.*)/initramfs.img   --	gen_context(system_u:object_r:usr_t,s0)
+
 # SuSE
 ifdef(`distro_suse', `
 /usr/bin/online_update		--	gen_context(system_u:object_r:rpm_exec_t,s0)


### PR DESCRIPTION
On ostree-managed systems for historical reasons we have the kernel
in multiple locations.  Unfortunately these locations have different
labels and hence can't be hardlinked.  But there's no real
reason to have separate labels, so consolidate them.

For more information, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1526191

Note this will change the label of the kernel in `/usr` even
for "traditional" yum-managed systems, but IMO it's better
anyways as `vmlinuz` isn't really a module.

Also probably ostree-related bits should be in a file different from `rpm.fc`
but I'm trying not to change too many things at once.