### PR TITLE
Allow install_t to chat with systemd over D-Bus

### DIFF
--- a/anaconda.te
+++ b/anaconda.te
@@ -84,6 +84,7 @@ allow install_t self:capability2 mac_admin;
 
 systemd_dbus_chat_localed(install_t)
 systemd_dbus_chat_logind(install_t)
+init_dbus_chat(install_t)
 
 tunable_policy(`deny_ptrace',`',`
 	domain_ptrace_all_domains(install_t)


### PR DESCRIPTION
An upcoming version of rpm-ostree will make use of systemd's D-Bus API.
Unfortunately, this is currently blocked by SELinux right now:

    subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:
    denied { send_msg } for msgtype=method_return dest=:1.23 spid=1
    tpid=1813 scontext=system_u:system_r:init_t:s0
    tcontext=unconfined_u:system_r:install_t:s0-s0:c0.c1023 tclass=dbus
    permissive=0

This patch adds a rule to allow rpm-ostree/anaconda to talk to systemd
over D-Bus.