### PR TITLE
Allow keepalived_t create and write a file under /tmp

### DIFF
--- a/keepalived.te
+++ b/keepalived.te
@@ -18,6 +18,9 @@ files_pid_file(keepalived_var_run_t)
 type keepalived_unconfined_script_exec_t;
 application_executable_file(keepalived_unconfined_script_exec_t)
 
+type keepalived_tmp_t;
+files_tmp_file(keepalived_tmp_t)
+
 ########################################
 #
 # keepalived local policy
@@ -62,6 +65,9 @@ dev_read_urand(keepalived_t)
 modutils_domtrans_insmod(keepalived_t)
 
 logging_send_syslog_msg(keepalived_t)
+
+allow keepalived_t keepalived_tmp_t:file { create_file_perms write_file_perms };
+files_tmp_filetrans(keepalived_t, keepalived_tmp_t, file)
 
 optional_policy(`
     iptables_domtrans(keepalived_t)


### PR DESCRIPTION
keepalived writes out its running statics to /tmp/keepalived.data when
it receives SIGUSR2. This change allows it.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>