### PR TITLE
Allow opendnssec daemon to execute ods-signer

### DIFF
--- a/opendnssec.te
+++ b/opendnssec.te
@@ -33,6 +33,9 @@ allow opendnssec_t self:process { fork signal_perms };
 allow opendnssec_t self:fifo_file rw_fifo_file_perms;
 allow opendnssec_t self:unix_stream_socket { create_stream_socket_perms connectto };
 
+# allow daemon to execute ods-signer (RHBZ#1537971)
+allow opendnssec_t opendnssec_exec_t:file { execute execute_no_trans };
+
 manage_files_pattern(opendnssec_t, opendnssec_conf_t,opendnssec_conf_t)
 manage_dirs_pattern(opendnssec_t, opendnssec_conf_t,opendnssec_conf_t)
 


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1537971

Signed-off-by: Christian Heimes <cheimes@redhat.com>