### PR TITLE
Allow certmonger_t domain to access /etc/pki/pki-tomcat BZ(1542600)

### DIFF
--- a/certmonger.te
+++ b/certmonger.te
@@ -32,7 +32,8 @@ files_tmp_file(certmonger_tmp_t)
 # Local policy
 #
 
-allow certmonger_t self:capability { chown  dac_read_search setgid setuid kill sys_nice };
+# certmonger requires DAC override to access /etc/pki/pki-tomcat/alias
+allow certmonger_t self:capability { chown dac_read_search dac_override setgid setuid kill sys_nice };
 dontaudit certmonger_t self:capability sys_tty_config;
 allow certmonger_t self:capability2 block_suspend;
 


### PR DESCRIPTION
Signed-off-by: Christian Heimes <cheimes@redhat.com>

See discussion on https://bugzilla.redhat.com/show_bug.cgi?id=1542600
certmonger requires DAC override because the NSSDB of Dogtag PKI is only accessible by user pkiuser and group pkiuser.