### PR TITLE
Update pkcs policy to include pkccsslotd.service

### DIFF
--- a/pkcs.fc
+++ b/pkcs.fc
@@ -2,6 +2,8 @@
 
 /usr/sbin/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_exec_t,s0)
 
+/usr/lib/systemd/system/pkcsslotd.service  gen_context(system_u:object_r:pkcs_slotd_unit_file_t,s0)
+
 /var/lib/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_var_lib_t,s0)
 
 /var/log/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_log_t,s0)

--- a/pkcs.te
+++ b/pkcs.te
@@ -37,6 +37,9 @@ type pkcs_slotd_tmpfs_t;
 typealias pkcs_slotd_tmpfs_t alias pkcsslotd_tmpfs_t;
 files_tmpfs_file(pkcs_slotd_tmpfs_t)
 
+type pkcs_slotd_unit_file_t;
+systemd_unit_file(pkcs_slotd_unit_file_t)
+
 ########################################
 #
 # Local policy


### PR DESCRIPTION
pkcsslotd.service was running, incorrectly, with default systemd label. Fixed it
by creating the pkcs_slotd_unit_file_t type and updating the file context.
This is also available on Refpolicy:
https://github.com/TresysTechnology/refpolicy-contrib/pull/67/commits/359430e4b9cac406b329fab8c68a574f80cd5ecf