### PR TITLE
Add allow to map for pki_tomcat_t

### DIFF
--- a/tomcat.if
+++ b/tomcat.if
@@ -65,6 +65,7 @@ template(`tomcat_domain_template',`
 	manage_files_pattern($1_t, $1_tmp_t, $1_tmp_t)
 	manage_fifo_files_pattern($1_t, $1_tmp_t, $1_tmp_t)
 	files_tmp_filetrans($1_t, $1_tmp_t, { file fifo_file dir })
+	allow $1_t $1_tmp_t:file map;	
 
 	can_exec($1_t, $1_exec_t)
 


### PR DESCRIPTION
On Fedora 27 there was an AVC denial:  
```
denied  { map } for pid=8761 comm="java" path="/tmp/hsperfdata_pkiuser/8761" dev="tmpfs" ino=131340 scontext=system_u:system_r:pki_tomcat_t:s0 tcontext=system_u:object_r:pki_tomcat_tmp_t:s0 tclass=file permissive=0
```