### PR TITLE
removed boinc dev_getattr_*_dev

### DIFF
--- a/boinc.te
+++ b/boinc.te
@@ -215,9 +215,6 @@ kernel_read_network_state(boinc_project_t)
 
 corenet_tcp_connect_boinc_port(boinc_project_t)
 
-dev_getattr_input_dev(boinc_t)
-dev_getattr_mouse_dev(boinc_t)
-
 files_dontaudit_search_home(boinc_project_t)
 
 term_getattr_ptmx(boinc_t)


### PR DESCRIPTION
boinc no longer needs permissions to run stat command on /dev/input/*
https://github.com/BOINC/boinc/pull/2463

Note: the affected boinc code never worked
https://github.com/BOINC/boinc/issues/1187
https://github.com/BOINC/boinc/issues/2335

Upstream pull request
https://github.com/TresysTechnology/refpolicy-contrib/pull/68

Signed-off-by: Germano Massullo <germano.massullo@gmail.com>