### PR TITLE
Allow git to mmap git_(sys|user)_content_t files BZ(1518027)

### DIFF
--- a/git.te
+++ b/git.te
@@ -105,6 +105,7 @@ allow git_session_t self:tcp_socket { accept listen };
 list_dirs_pattern(git_session_t, git_user_content_t, git_user_content_t)
 read_files_pattern(git_session_t, git_user_content_t, git_user_content_t)
 userdom_search_user_home_dirs(git_session_t)
+allow git_session_t git_user_content_t:file map;
 
 kernel_read_system_state(git_session_t)
 
@@ -153,6 +154,7 @@ tunable_policy(`use_samba_home_dirs',`
 
 list_dirs_pattern(git_system_t, git_sys_content_t, git_sys_content_t)
 read_files_pattern(git_system_t, git_sys_content_t, git_sys_content_t)
+allow git_system_t git_sys_content_t:file map;
 
 kernel_read_network_state(git_system_t)
 kernel_read_system_state(git_system_t)
@@ -178,6 +180,7 @@ tunable_policy(`git_system_enable_homedirs',`
 	list_dirs_pattern(git_script_t, git_user_content_t, git_user_content_t)
 	list_dirs_pattern(git_system_t, git_user_content_t, git_user_content_t)
 	read_files_pattern(git_system_t, git_user_content_t, git_user_content_t)
+	allow git_system_t git_user_content_t:file map;
 
 ')
 


### PR DESCRIPTION
I tested this on f28 with `git-daemon`.  I tested clone, fetch, and ls-remote on system repositories (in the default /var/lib/git) and user repositories (in ~user/public_git).

I did not test with `git-http-backend` so I'm not sure if that requires anything further.

I'm also not sure whether the allow for `git_session_t` is needed or not.