### PR TITLE
Allow callers of git_read_generic_sys_content_files() to map git_sys_content_t BZ(1518027)

### DIFF
--- a/git.if
+++ b/git.if
@@ -67,7 +67,8 @@ interface(`git_read_generic_sys_content_files',`
 
 	list_dirs_pattern($1, git_sys_content_t, git_sys_content_t)
 	read_files_pattern($1, git_sys_content_t, git_sys_content_t)
-    read_lnk_files_pattern($1, git_sys_content_t, git_sys_content_t)
+	read_lnk_files_pattern($1, git_sys_content_t, git_sys_content_t)
+	allow $1 git_sys_content_t:file map;
 
 	files_search_var_lib($1)
 


### PR DESCRIPTION
Fix whitespace of read_lnk_files_pattern() call while here.

This follows up on #53 and should fix usage of git-http-backend (i.e. git smart http).  Sorry I didn't find this before submitting the initial pull request.  Hopefully this resolves the mmap AVC's for git.  I also see that lighttpd and nginx appear to be covered in the apache module.  I only tested with apache.