### PR TITLE
Update tlp runtime path

### DIFF
--- a/tlp.fc
+++ b/tlp.fc
@@ -4,4 +4,4 @@
 
 /var/lib/tlp(/.*)?		gen_context(system_u:object_r:tlp_var_lib_t,s0)
 
-/var/run/tlp(/.*)?		gen_context(system_u:object_r:tlp_var_run_t,s0)
+/run/tlp(/.*)?			gen_context(system_u:object_r:tlp_var_run_t,s0)


### PR DESCRIPTION
As we ship version 1.1.x in F27 already, the change of TLP from
`/var/run` to `/run/tlp` as their RUN-dir is included.[(Details)][1] This causes
various issues reported on [bugzilla][2].

This commit should fix the currently still wrong file context for these
runtime files.

[1]: https://github.com/linrunner/TLP/commit/168a96ffad34e407cbd4e02a952828f08fd1badc
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1510249