### PR TITLE
 Allow sssd_selinux_manager_t domain to chat with systemd 

### DIFF
--- a/sssd.te
+++ b/sssd.te
@@ -204,4 +204,8 @@ seutil_manage_default_contexts(sssd_selinux_manager_t)
 
 seutil_exec_setfiles(sssd_selinux_manager_t)
 logging_dontaudit_search_audit_logs(sssd_selinux_manager_t)
-
+# allow to communicate with systemd via libnss_systemd.so.2
+optional_policy(`
+    dbus_system_bus_client(sssd_selinux_manager_t)
+    init_dbus_chat(sssd_selinux_manager_t)
+')


### PR DESCRIPTION
It would be good to backport these patches also to f26+