### PR TITLE
Add tpm2-abrmd policy

### DIFF
--- a/dbus.te
+++ b/dbus.te
@@ -236,6 +236,10 @@ optional_policy(`
     unconfined_server_domtrans(system_dbusd_t)
 ')
 
+optional_policy(`
+        tabrmd_rw_inherited_unix_stream_sockets(system_dbusd_t)
+')
+
 ########################################
 #
 # system_bus_type rules

--- a/tabrmd.fc
+++ b/tabrmd.fc
@@ -1,0 +1,1 @@
+/usr/sbin/tpm2-abrmd	--	gen_context(system_u:object_r:tabrmd_exec_t,s0)

--- a/tabrmd.if
+++ b/tabrmd.if
@@ -1,0 +1,38 @@
+## <summary>policy for tpm2-abrmd</summary>
+
+########################################
+## <summary>
+##	Use and inherit tabrmd file descriptors.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tabrmd_use_fds',`
+	gen_require(`
+		type tabrmd_t;
+	')
+
+	allow $1 tabrmd_t:fd use;
+')
+
+########################################
+## <summary>
+##	Read and write inherited tabrmd unix stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tabrmd_rw_inherited_unix_stream_sockets',`
+	gen_require(`
+		type tabrmd_t;
+	')
+
+        tabrmd_use_fds($1)
+	allow $1 tabrmd_t:unix_stream_socket { read write };
+')

--- a/tabrmd.te
+++ b/tabrmd.te
@@ -1,0 +1,17 @@
+policy_module(tabrmd, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type tabrmd_t;
+type tabrmd_exec_t;
+init_daemon_domain(tabrmd_t, tabrmd_exec_t)
+
+dev_rw_tpm(tabrmd_t)
+logging_send_syslog_msg(tabrmd_t)
+
+optional_policy(`
+    dbus_system_domain(tabrmd_t, tabrmd_exec_t)
+')


### PR DESCRIPTION
The tpm2-abrmd is a user-space D-Bus based TPM2 Access Broker and Resource
Manager. Applications communicate with the tpm2-abrmd by sending commands
and receiving responses using a communication library (TCTI) that used to
create a pipe(2) to send the data to the daemon.

But this communication mechanism was changed to use unix sockets instead
and pass the file descriptors to the D-Bus daemon, so a SELinux policy is
needed to update the tpm2-abrmd to the latest version that use sockets.

This patch is based on the SELinux policy module that's in the tpm2-abrmd
upstream repository, with the changes suggested by Dominick Grift.

Suggested-by: Dominick Grift <dac.override@gmail.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>