### PR TITLE
Enable conntrackd to be NET_ADMIN

### DIFF
--- a/conntrackd.te
+++ b/conntrackd.te
@@ -33,7 +33,7 @@ files_lock_file(conntrackd_var_lock_t)
 #
 #
 
-allow conntrackd_t self:capability { sys_nice };
+allow conntrackd_t self:capability { sys_nice net_admin };
 allow conntrackd_t self:netlink_route_socket rw_netlink_socket_perms;
 allow conntrackd_t self:netlink_netfilter_socket create_socket_perms;
 allow conntrackd_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
Since it do access netfilter and various others part of the
network stack, the capability is kinda required.

Without it, it fail with "can't open channel socket"