### PR TITLE
mysql: Add same SELinux context for symlink as binary

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -29,6 +29,7 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
 
+/usr/sbin/mysqld(-max|-debug)?	-l	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/sbin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/sbin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
 /usr/sbin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)


### PR DESCRIPTION
We are unsure if in case of mysql we need to have same label for backward compatible symlink /usr/sbin/mysqld as target /usr/libexec/mysqld. In case it is advised to. This PR adds it, otherwise close it unmerged.
Thanks.