### PR TITLE
Add correct namespace_init_exec_t context to /etc/security/namespace.d/*

### DIFF
--- a/namespace.fc
+++ b/namespace.fc
@@ -1,3 +1,4 @@
 
 /etc/security/namespace.init		--	gen_context(system_u:object_r:namespace_init_exec_t,s0)
+/etc/security/namespace\.d(/.*)?		--	gen_context(system_u:object_r:namespace_init_exec_t,s0)
 

--- a/rpm.te
+++ b/rpm.te
@@ -222,6 +222,10 @@ userdom_use_inherited_user_terminals(rpm_t)
 userdom_use_unpriv_users_fds(rpm_t)
 
 optional_policy(`
+	domain_named_filetrans(rpm_t)
+')
+
+optional_policy(`
 	cron_system_entry(rpm_t, rpm_exec_t)
 ')
 


### PR DESCRIPTION
That is the default directory that pam_namespace searches when
custom init scripts are specified with iscript=your_custom_script