### PR TITLE
Conntrackd need to load kernel module to work

### DIFF
--- a/conntrackd.te
+++ b/conntrackd.te
@@ -60,6 +60,7 @@ manage_files_pattern(conntrackd_t, conntrackd_var_lock_t, conntrackd_var_lock_t)
 files_lock_filetrans(conntrackd_t, conntrackd_var_lock_t, { dir file sock_file })
 
 kernel_read_network_state(conntrackd_t)
+kernel_request_load_module(conntrackd_t)
 corenet_udp_sendrecv_generic_if(conntrackd_t)
 corenet_udp_sendrecv_generic_node(conntrackd_t)
 corenet_udp_sendrecv_all_ports(conntrackd_t)


### PR DESCRIPTION
Otherwise, it fail with the following audit log:

    type=AVC msg=audit(1535552219.384:140): avc:  denied  { module_request } for  pid=806 comm="conntrackd" kmod="nfnetlink-subsys-1" scontext=system_u:system_r:conntrackd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0