### PR TITLE
Revert "Allow firewalld_t domain to read random device"

### DIFF
--- a/firewalld.te
+++ b/firewalld.te
@@ -79,7 +79,6 @@ files_list_kernel_modules(firewalld_t)
 corecmd_exec_bin(firewalld_t)
 corecmd_exec_shell(firewalld_t)
 
-dev_read_rand(firewalld_t)
 dev_read_urand(firewalld_t)
 dev_search_sysfs(firewalld_t)
 


### PR DESCRIPTION
This reverts commit f3bb84dd5f0be27b0a74180f39bca25f4d9a4cdf.

Access to /dev/random was done due to bug in openssl
rhbz#1624554

I cannot see any AVC with fixed version of openssl. I tried to restart firewalld twice.