### PR TITLE
Add nagios_send_cmd interface to give access to the cmd fifo

### DIFF
--- a/nagios.fc
+++ b/nagios.fc
@@ -30,6 +30,8 @@
 /var/spool/nagios(/.*)?					gen_context(system_u:object_r:nagios_spool_t,s0)
 /var/spool/icinga(/.*)?					gen_context(system_u:object_r:nagios_spool_t,s0)
 
+/var/spool/nagios/cmd/nagios.cmd					gen_context(system_u:object_r:nagios_cmd_t,s0)
+
 ifdef(`distro_debian',`
 /usr/sbin/nagios				--	gen_context(system_u:object_r:nagios_exec_t,s0)
 ')

--- a/nagios.if
+++ b/nagios.if
@@ -334,3 +334,21 @@ interface(`nagios_unconfined_signull',`
 
 	allow $1 nagios_unconfined_plugin_t:process signull;
 ')
+
+########################################
+## <summary>
+##      Allow the domain to send command to nagios with the nagios.cmd pipe.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`nagios_send_cmd',`
+	gen_require(`
+		type nagios_cmd_t;
+	')
+
+	allow $1 nagios_cmd_t:fifo rw_fifo_file_perms;
+')

--- a/nagios.te
+++ b/nagios.te
@@ -47,6 +47,9 @@ init_script_file(nagios_initrc_exec_t)
 type nagios_log_t;
 logging_log_file(nagios_log_t)
 
+type nagios_cmd_t;
+files_type(nagios_cmd_t)
+
 type nagios_tmp_t;
 files_tmp_file(nagios_tmp_t)
 
@@ -146,7 +149,7 @@ files_tmp_filetrans(nagios_t, nagios_tmp_t, { dir file })
 manage_files_pattern(nagios_t, nagios_var_run_t, nagios_var_run_t)
 files_pid_filetrans(nagios_t, nagios_var_run_t, file)
 
-manage_fifo_files_pattern(nagios_t, nagios_spool_t, nagios_spool_t)
+manage_fifo_files_pattern(nagios_t, nagios_cmd_t, nagios_cmd_t)
 manage_files_pattern(nagios_t, nagios_spool_t, nagios_spool_t)
 manage_sock_files_pattern(nagios_t, nagios_spool_t, nagios_spool_t)
 files_spool_filetrans(nagios_t, nagios_spool_t, { file fifo_file })


### PR DESCRIPTION
The cmd fifo is used by software such as nsca to trigger alert
in nagios.