### PR TITLE
sysstat: grant sysstat_t the search_dir_perms set

### DIFF
--- a/sysstat.te
+++ b/sysstat.te
@@ -44,6 +44,7 @@ dev_read_urand(sysstat_t)
 
 files_search_var(sysstat_t)
 files_read_etc_runtime_files(sysstat_t)
+files_search_all_mountpoints(sysstat_t)
 
 fs_getattr_all_fs(sysstat_t)
 fs_list_inotifyfs(sysstat_t)


### PR DESCRIPTION
The sadc utility from sysstat that collects filesystem stats (-F flag)
cannot access /var/log/audit (auditd_log_t) if it is a mountpoint

Resolves: rhbz#1637416

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>