### PR TITLE
Allow arpwatch_t domains to execute shell BZ(1644568)

### DIFF
--- a/arpwatch.te
+++ b/arpwatch.te
@@ -58,6 +58,8 @@ kernel_read_kernel_sysctls(arpwatch_t)
 kernel_read_proc_symlinks(arpwatch_t)
 kernel_request_load_module(arpwatch_t)
 
+corecmd_exec_shell(arpwatch_t)
+
 corenet_all_recvfrom_netlabel(arpwatch_t)
 corenet_tcp_sendrecv_generic_if(arpwatch_t)
 corenet_udp_sendrecv_generic_if(arpwatch_t)


### PR DESCRIPTION
Sending e-mails is a part of core functionality of arpwatch.
If esmtp package is installed to provide the sendmail capability,
the permission to execute shell_exec_t for arpwatch_t is required
as esmtp actually provides a shell wrapper.

The arpwatch service runs as an unprivileged user, so granting
this permission should not be considered as too excessive.

Fedoras 29 and 28 are affected.

Signed-off-by: Zdenek Pytela <zdenek@pytela.net>