### PR TITLE
Label /var/lib/arpwatch/.esmtp_queue as mail_home_rw_t BZ(1657327)

### DIFF
--- a/mta.fc
+++ b/mta.fc
@@ -17,7 +17,7 @@ ifdef(`distro_redhat',`
 /root/\.forward		--	gen_context(system_u:object_r:mail_home_t,s0)
 /root/dead\.letter	--	gen_context(system_u:object_r:mail_home_t,s0)
 /root/\.mailrc		--	gen_context(system_u:object_r:mail_home_t,s0)
-/root/\.esmtp_queue(/.*)?     gen_context(system_u:object_r:mail_home_rw_t,s0)
+/root/\.esmtp_queue(/.*)?	gen_context(system_u:object_r:mail_home_rw_t,s0)
 /root/Maildir(/.*)?		gen_context(system_u:object_r:mail_home_rw_t,s0)
 
 /usr/bin/esmtp		-- gen_context(system_u:object_r:sendmail_exec_t,s0)
@@ -38,3 +38,5 @@ ifdef(`distro_redhat',`
 /var/spool/mqueue\.in(/.*)?	gen_context(system_u:object_r:mqueue_spool_t,s0)
 /var/spool/mail(/.*)?		gen_context(system_u:object_r:mail_spool_t,s0)
 /var/spool/smtpd(/.*)?		gen_context(system_u:object_r:mail_spool_t,s0)
+
+/var/lib/arpwatch/\.esmtp_queue(/.*)?	gen_context(system_u:object_r:mail_home_rw_t,s0)


### PR DESCRIPTION
If esmtp package is installed to provide the sendmail rpm-capability,
the ~arpwatch/.esmtp_queue directory has to have the right label
so that the daemon is able to send e-mails.

Fedoras 29 and 28 are affected.

Signed-off-by: Zdenek Pytela <zpytela@redhat.com>