### PR TITLE
Add file transition for /var/lib/arpwatch/.esmtp_queue

### DIFF
--- a/arpwatch.if
+++ b/arpwatch.if
@@ -190,3 +190,37 @@ interface(`arpwatch_admin',`
 	admin_pattern($1, arpwatch_unit_file_t)
 	allow $1 arpwatch_unit_file_t:service all_service_perms;
 ')
+
+########################################
+## <summary>
+##	Create objects in the arpwatch home directory
+##	with an automatic type transition to a specified type
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="type">
+##	<summary>
+##	The type of the object being created.
+##	</summary>
+## </param>
+## <param name="object">
+##      <summary>
+##      The class of the object being created.
+##      </summary>
+## </param>
+## <param name="name">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`arpwatch_data_filetrans',`
+	gen_require(`
+		type arpwatch_data_t;
+	')
+
+	filetrans_pattern($1, arpwatch_data_t, $2, $3, $4)
+')

--- a/mta.fc
+++ b/mta.fc
@@ -14,6 +14,8 @@ ifdef(`distro_redhat',`
 /etc/postfix/aliases.*		gen_context(system_u:object_r:etc_aliases_t,s0)
 ')
 
+/var/lib/arpwatch/\.esmtp_queue(/.*)?	gen_context(system_u:object_r:mail_home_rw_t,s0)
+
 /root/\.forward		--	gen_context(system_u:object_r:mail_home_t,s0)
 /root/dead\.letter	--	gen_context(system_u:object_r:mail_home_t,s0)
 /root/\.mailrc		--	gen_context(system_u:object_r:mail_home_t,s0)

--- a/mta.te
+++ b/mta.te
@@ -121,6 +121,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	arpwatch_data_filetrans(system_mail_t, mail_home_rw_t, dir, ".esmtp_queue")
+')
+
+optional_policy(`
 	courier_manage_spool_dirs(user_mail_domain)
 	courier_manage_spool_files(user_mail_domain)
 	courier_rw_spool_pipes(user_mail_domain)


### PR DESCRIPTION
Add file transition so that system_mail_t can in the /var/lib/arpwatch directory
with arpwatch_data_t context create .esmtp_queue directory with mail_home_rw_t context.
It is required for the arpwatch service being able to send emails.

Signed-off-by: Zdenek Pytela <zpytela@redhat.com>