### PR TITLE
This is a proposed fix for https://jira.mongodb.org/browse/SERVER-38704

### DIFF
--- a/mongodb.te
+++ b/mongodb.te
@@ -60,6 +60,15 @@ manage_files_pattern(mongod_t, mongod_tmp_t, mongod_tmp_t)
 manage_sock_files_pattern(mongod_t, mongod_tmp_t, mongod_tmp_t)
 files_tmp_filetrans(mongod_t, mongod_tmp_t, { file dir sock_file })
 
+## In MongoDB 3.4.16, 3.6.6, 4.0.0 and later, mongod tries to read netstat
+## info from /proc/net and store it in its diagnostic system (FTDC).
+## See: https://jira.mongodb.org/browse/SERVER-31400
+## This means that we need to adjust the policy so that the mongod
+## process is allowed to open and read /proc/net/netstat, which
+## also typically has symlinks (e.g. /proc/net/snmp).
+kernel_list_proc(mongod_t)
+kernel_read_proc_symlinks(mongod_t)
+
 kernel_read_system_state(mongod_t)
 kernel_read_network_state(mongod_t)
 kernel_read_vm_sysctls(mongod_t)


### PR DESCRIPTION
In MongoDB 3.4.16, 3.6.6, 4.0.0 and later, mongod tries to read netstat info from /proc/net and store it in its diagnostic system (FTDC). See: https://jira.mongodb.org/browse/SERVER-31400

This means that we need to adjust the policy so that the mongod process is allowed to open and read /proc/net/netstat, which also typically has symlinks (e.g. /proc/net/snmp).