### PR TITLE
Fix for allow gpg_t to create own tmpfs dirs and sockets

### DIFF
--- a/gpg.te
+++ b/gpg.te
@@ -43,6 +43,11 @@ typealias gpg_agent_tmp_t alias { user_gpg_agent_tmp_t staff_gpg_agent_tmp_t sys
 typealias gpg_agent_tmp_t alias { auditadm_gpg_agent_tmp_t secadm_gpg_agent_tmp_t };
 userdom_user_tmp_file(gpg_agent_tmp_t)
 
+type gpg_agent_tmpfs_t;
+typealias gpg_agent_tmpfs_t alias { user_gpg_agent_tmpfs_t staff_gpg_agent_tmpfs_t sysadm_gpg_agent_tmpfs_t };
+typealias gpg_agent_tmpfs_t alias { auditadm_gpg_agent_tmpfs_t secadm_gpg_agent_tmpfs_t };
+userdom_user_tmpfs_file(gpg_agent_tmpfs_t)
+
 type gpg_secret_t;
 typealias gpg_secret_t alias { user_gpg_secret_t staff_gpg_secret_t sysadm_gpg_secret_t };
 typealias gpg_secret_t alias { auditadm_gpg_secret_t secadm_gpg_secret_t };
@@ -265,10 +270,10 @@ manage_files_pattern(gpg_agent_t, gpg_agent_tmp_t, gpg_agent_tmp_t)
 manage_sock_files_pattern(gpg_agent_t, gpg_agent_tmp_t, gpg_agent_tmp_t)
 files_tmp_filetrans(gpg_agent_t, gpg_agent_tmp_t, { file sock_file dir })
 
-manage_dirs_pattern(gpg_t, gpg_tmpfs_t, gpg_tmpfs_t)
-manage_files_pattern(gpg_t, gpg_tmpfs_t, gpg_tmpfs_t)
-manage_sock_files_pattern(gpg_t, gpg_tmpfs_t, gpg_tmpfs_t)
-fs_tmpfs_filetrans(gpg_t, gpg_tmpfs_t, { dir file sock_file })
+manage_dirs_pattern(gpg_agent_t, gpg_agent_tmpfs_t, gpg_agent_tmpfs_t)
+manage_files_pattern(gpg_agent_t, gpg_agent_tmpfs_t, gpg_agent_tmpfs_t)
+manage_sock_files_pattern(gpg_agent_t, gpg_agent_tmpfs_t, gpg_agent_tmpfs_t)
+fs_tmpfs_filetrans(gpg_agent_t, gpg_agent_tmpfs_t, { dir file sock_file })
 
 # allow gpg to connect to the gpg agent
 stream_connect_pattern(gpg_t, gpg_agent_tmp_t, gpg_agent_tmp_t, gpg_agent_t)


### PR DESCRIPTION
This commit fixes previous commit 7d5c4524487d8f0994839e66d6819ab21c5b0a2a
introducing incorrect labels for the tmpfs filetrans

Signed-off-by: Zdenek Pytela <zpytela@redhat.com>