### PR TITLE
Allow vhostmd_t read libvirt configuration files

### DIFF
--- a/vhostmd.te
+++ b/vhostmd.te
@@ -73,6 +73,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	virt_read_config(vhostmd_t)
 	virt_stream_connect(vhostmd_t)
 	virt_write_content(vhostmd_t)
     virt_rw_svirt_image(vhostmd_t)


### PR DESCRIPTION
Signed-off-by: Zdenek Pytela <zpytela@redhat.com>