### PR TITLE
Allow dovecot_t to connect to MySQL UNIX socket

### DIFF
--- a/dovecot.te
+++ b/dovecot.te
@@ -210,6 +210,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mysql_read_config(dovecot_t)
+	mysql_stream_connect(dovecot_t)
+')
+
+optional_policy(`
 	# Handle sieve scripts
 	sendmail_domtrans(dovecot_t)
 ')


### PR DESCRIPTION
Dovecot can be configured to connect to MySQL via a UNIX stream socket.
Let's allow it to work in this configuration.

Link: https://lists.fedoraproject.org/archives/list/selinux@lists.fedoraproject.org/thread/Q5BN6EMSFELSUFN62K3CDTAUDI2ARWQA/
Reported-by: Robert Moskowitz <rgm@htt-consult.com>
Signed-off-by: Ondrej Mosnacek <omosnacek@gmail.com>