### PR TITLE
Red Hat Bug 1627075 - Create a SELinux boolean to disable cron-logrotate transition

### DIFF
--- a/logrotate.te
+++ b/logrotate.te
@@ -238,6 +238,9 @@ optional_policy(`
 
 optional_policy(`
 	callweaver_exec(logrotate_t)
+')
+
+optional_policy(`
 	callweaver_stream_connect(logrotate_t)
 ')
 

--- a/logrotate.te
+++ b/logrotate.te
@@ -248,8 +248,8 @@ optional_policy(`
 #Red Hat bug 1627075
 optional_policy(`
 	tunable_policy(`cron_logrotate_transition_disabled',`
-                cron_system_entry(logrotate_t, logrotate_exec_t)
-        ')
+		cron_system_entry(logrotate_t, logrotate_exec_t)
+	')
 	cron_search_spool(logrotate_t)
 ')
 

--- a/logrotate.te
+++ b/logrotate.te
@@ -23,6 +23,13 @@ gen_tunable(logrotate_use_nfs, false)
 ## </desc>
 gen_tunable(logrotate_read_inside_containers, false)
 
+## <desc>
+## <p>
+## Disable cron-logrotate transition 
+## </p>
+## </desc>
+gen_tunable(cron_logrotate_transition_disabled, false)
+
 
 type logrotate_t;
 domain_type(logrotate_t)
@@ -239,7 +246,10 @@ optional_policy(`
 ')
 
 optional_policy(`
-	cron_system_entry(logrotate_t, logrotate_exec_t)
+        #Red Hat bug 1627075
+	tunable_policy(`cron_logrotate_transition_disabled',`
+                cron_system_entry(logrotate_t, logrotate_exec_t)
+        ')
 	cron_search_spool(logrotate_t)
 ')
 

--- a/logrotate.te
+++ b/logrotate.te
@@ -253,6 +253,9 @@ optional_policy(`
 	tunable_policy(`cron_logrotate_transition_disabled',`
 		cron_system_entry(logrotate_t, logrotate_exec_t)
 	')
+')
+
+optional_policy(`
 	cron_search_spool(logrotate_t)
 ')
 

--- a/logrotate.te
+++ b/logrotate.te
@@ -245,7 +245,6 @@ optional_policy(`
 	consoletype_exec(logrotate_t)
 ')
 
-#Red Hat bug 1627075
 optional_policy(`
 	tunable_policy(`cron_logrotate_transition_disabled',`
 		cron_system_entry(logrotate_t, logrotate_exec_t)

--- a/logrotate.te
+++ b/logrotate.te
@@ -245,8 +245,8 @@ optional_policy(`
 	consoletype_exec(logrotate_t)
 ')
 
+#Red Hat bug 1627075
 optional_policy(`
-        #Red Hat bug 1627075
 	tunable_policy(`cron_logrotate_transition_disabled',`
                 cron_system_entry(logrotate_t, logrotate_exec_t)
         ')

--- a/logrotate.te
+++ b/logrotate.te
@@ -245,13 +245,9 @@ optional_policy(`
 	consoletype_exec(logrotate_t)
 ')
 
-optional_policy(`
-	tunable_policy(`cron_logrotate_transition_disabled',`
-		cron_system_entry(logrotate_t, logrotate_exec_t)
-	')
-')
 
-optional_policy(`
+tunable_policy(`cron_logrotate_transition_disabled',`
+	cron_system_entry(logrotate_t, logrotate_exec_t)
 	cron_search_spool(logrotate_t)
 ')
 

--- a/logrotate.te
+++ b/logrotate.te
@@ -238,9 +238,6 @@ optional_policy(`
 
 optional_policy(`
 	callweaver_exec(logrotate_t)
-')
-
-optional_policy(`
 	callweaver_stream_connect(logrotate_t)
 ')
 


### PR DESCRIPTION
I think this is enough to implement the requested feature in the Bugzilla ticket. Please correct me if I am wrong.