### PR TITLE
Allow tcpd bind to services ports BZ(1676940)

### DIFF
--- a/tcpd.te
+++ b/tcpd.te
@@ -29,6 +29,19 @@ corenet_tcp_sendrecv_generic_node(tcpd_t)
 corenet_tcp_sendrecv_all_ports(tcpd_t)
 corenet_tcp_bind_generic_node(tcpd_t)
 
+# Allow tcpd_t bind to ports for services where there is a transition defined
+corenet_tcp_bind_ircd_port(tcpd_t)
+corenet_tcp_bind_interwise_port(tcpd_t)
+corenet_tcp_bind_fingerd_port(tcpd_t)
+corenet_tcp_bind_inetd_child_port(tcpd_t)
+corenet_tcp_bind_rlogind_port(tcpd_t)
+corenet_tcp_bind_rlogin_port(tcpd_t)
+corenet_tcp_bind_rsh_port(tcpd_t)
+corenet_tcp_bind_all_rpc_ports(tcpd_t)
+corenet_tcp_bind_telnetd_port(tcpd_t)
+corenet_tcp_bind_xserver_port(tcpd_t)
+corenet_tcp_bind_vnc_port(tcpd_t)
+
 fs_getattr_xattr_fs(tcpd_t)
 
 corecmd_exec_bin(tcpd_t)


### PR DESCRIPTION
tcpd from tcp_wrappers is a network services superserver
working similar to inet.
tcpd_t needs to bind to ports for those services where a transition
from tcpd_t exists in the policy.

This patch is needed to complete BZ(1676940).

Signed-off-by: Zdenek Pytela <zpytela@redhat.com>