### PR TITLE
Add permissions needed by systemd's machinectl shell/login (Attempt 2)

### DIFF
--- a/dbus.te
+++ b/dbus.te
@@ -128,6 +128,8 @@ selinux_compute_relabel_context(system_dbusd_t)
 selinux_compute_user_contexts(system_dbusd_t)
 
 term_dontaudit_use_console(system_dbusd_t)
+term_use_ptmx(system_dbusd_t)
+term_use_all_ptys(system_dbusd_t)
 
 auth_use_nsswitch(system_dbusd_t)
 auth_read_pam_console_data(system_dbusd_t)


### PR DESCRIPTION
This is some work on fixing the machinectl shell and machinectl login commands.

Relevant bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=1219729
https://bugzilla.redhat.com/show_bug.cgi?id=1257990
https://bugzilla.redhat.com/show_bug.cgi?id=1416540

Tested on F29, this allows machinectl shell and machinectl login to work for local root login. Have not tested with container logins.

See also pull request to selinux-policy
See also pull request #17 (previous attempt)