### PR TITLE
Fix varnisncsa typo

### DIFF
--- a/varnishd.fc
+++ b/varnishd.fc
@@ -5,7 +5,7 @@
 /etc/varnish(/.*)?	gen_context(system_u:object_r:varnishd_etc_t,s0)
 
 /usr/bin/varnishlog	--	gen_context(system_u:object_r:varnishlog_exec_t,s0)
-/usr/bin/varnisncsa	--	gen_context(system_u:object_r:varnishlog_exec_t,s0)
+/usr/bin/varnishncsa	--	gen_context(system_u:object_r:varnishlog_exec_t,s0)
 
 /usr/sbin/varnishd	--	gen_context(system_u:object_r:varnishd_exec_t,s0)
 


### PR DESCRIPTION
This may lead varnishncsa.service failing in enforcing mode.