### PR TITLE
Revert bad fix breaking gnome_filetrans_fontconfig_home_content()

### DIFF
--- a/gnome.if
+++ b/gnome.if
@@ -1720,7 +1720,6 @@ gen_require(`
 	filetrans_pattern($1, data_home_t,  gkeyringd_gnome_home_t, dir, "keyrings")
 	filetrans_pattern($1, gconf_home_t, data_home_t, dir, "share")
 	filetrans_pattern($1, data_home_t, icc_data_home_t, dir, "icc")
-	filetrans_pattern($1, cache_home_t, cache_home_t, dir, "fontconfig")
 	userdom_user_tmp_filetrans($1, config_home_t, dir, "dconf")
 	gnome_cache_filetrans($1, config_home_t, dir, "dconf")
 	gnome_filetrans_gstreamer_home_content($1)


### PR DESCRIPTION
Revert bad fix breaking the new interface gnome_filetrans_fontconfig_home_content
which was added to resolve BZ(1659905)
https://github.com/fedora-selinux/selinux-policy-contrib/pull/97

Revert "Fix gnome_filetrans_home_content() to include also "fontconfig" dir as cache_home_t"

This reverts commit b163f88628dd4dbbcff88427c944356f4ca54ca7.