### PR TITLE
Deamon rhsmcertd is able to install certs for docker again

### DIFF
--- a/rhsmcertd.if
+++ b/rhsmcertd.if
@@ -358,5 +358,4 @@ interface(`rhsmcertd_admin',`
 
     files_search_locks($1)
     admin_pattern($1, rhsmcertd_lock_t)
-
 ')

--- a/rhsmcertd.te
+++ b/rhsmcertd.te
@@ -176,3 +176,7 @@ optional_policy(`
 optional_policy(`
     unconfined_server_signull(rhsmcertd_t)
 ')
+
+optional_policy(`
+    container_manage_config_files(rhsmcertd_t)
+')


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1671534
* Deamon rhsmcertd wasn't able to install entitlement certificates
  for docker. More details are in bug report. This change fixes
  this issue.