### PR TITLE
Allow systemd to execute sa-update in spamd_update_t domain BZ(1705331)

### DIFF
--- a/spamassassin.te
+++ b/spamassassin.te
@@ -29,7 +29,7 @@ gen_tunable(spamd_update_can_network, false)
 
 type spamd_update_t;
 type spamd_update_exec_t;
-application_domain(spamd_update_t, spamd_update_exec_t)
+init_system_domain(spamd_update_t, spamd_update_exec_t)
 role system_r types spamd_update_t;
 
 type spamd_t;


### PR DESCRIPTION
Replace application_domain with init_system_domain for spamd_update_exec_t.
The /usr/share/spamassassin/sa-update.cron file is now labeled with
spamd_update_exec_t since commit db62634 and it is called off a timer unit file.