### PR TITLE
Add fcontext for apachectl util to fix missing output

### DIFF
--- a/apache.fc
+++ b/apache.fc
@@ -62,6 +62,7 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:objec
 /usr/lib/lighttpd(/.*)?		gen_context(system_u:object_r:httpd_modules_t,s0)
 
 /usr/sbin/apache(2)?		--	gen_context(system_u:object_r:httpd_exec_t,s0)
+/usr/sbin/apachectl		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/sbin/apache-ssl(2)?	--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/sbin/cherokee		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/sbin/httpd\.event		--	gen_context(system_u:object_r:httpd_exec_t,s0)


### PR DESCRIPTION
when executed "httpd -t" from this script.