### PR TITLE
Grant varnishlog_t access to varnishd_etc_t

### DIFF
--- a/varnishd.te
+++ b/varnishd.te
@@ -144,3 +144,4 @@ read_files_pattern(varnishlog_t, varnishd_var_lib_t, varnishd_var_lib_t)
 allow varnishlog_t varnishd_var_lib_t:file map;
 
 files_search_var_lib(varnishlog_t)
+varnishd_read_config(varnishlog_t)


### PR DESCRIPTION
The varnishncsa program has a -f \<file\> option that reads the NCSA
format string from a file to work around shell expansion pitfalls of
its -F \<format\> counterpart. For that the logical location would be
/etc/varnish where other varnish configuration files live.

It is fine to also grant varnishlog access to this location. Even
though there is currently no use case for it today, there are plans
that would require this access too.

This applies to all active Fedora branches today.