### PR TITLE
[speech-dispatcher.if] m4 macro names can not have - in them

### DIFF
--- a/speech-dispatcher.if
+++ b/speech-dispatcher.if
@@ -11,7 +11,7 @@
 ## </summary>
 ## </param>
 #
-interface(`speech-dispatcher_domtrans',`
+interface(`speech_dispatcher_domtrans',`
 	gen_require(`
 		type speech-dispatcher_t, speech-dispatcher_exec_t;
 	')
@@ -30,7 +30,7 @@ interface(`speech-dispatcher_domtrans',`
 ## </param>
 ## <rolecap/>
 #
-interface(`speech-dispatcher_read_log',`
+interface(`speech_dispatcher_read_log',`
 	gen_require(`
 		type speech-dispatcher_log_t;
 	')
@@ -49,7 +49,7 @@ interface(`speech-dispatcher_read_log',`
 ##	</summary>
 ## </param>
 #
-interface(`speech-dispatcher_append_log',`
+interface(`speech_dispatcher_append_log',`
 	gen_require(`
 		type speech-dispatcher_log_t;
 	')
@@ -68,7 +68,7 @@ interface(`speech-dispatcher_append_log',`
 ##	</summary>
 ## </param>
 #
-interface(`speech-dispatcher_manage_log',`
+interface(`speech_dispatcher_manage_log',`
 	gen_require(`
 		type speech-dispatcher_log_t;
 	')
@@ -88,7 +88,7 @@ interface(`speech-dispatcher_manage_log',`
 ##	</summary>
 ## </param>
 #
-interface(`speech-dispatcher_systemctl',`
+interface(`speech_dispatcher_systemctl',`
 	gen_require(`
 		type speech-dispatcher_t;
 		type speech-dispatcher_unit_file_t;
@@ -116,7 +116,7 @@ interface(`speech-dispatcher_systemctl',`
 ## </param>
 ## <rolecap/>
 #
-interface(`speech-dispatcher_admin',`
+interface(`speech_dispatcher_admin',`
 	gen_require(`
 		type speech-dispatcher_t;
 		type speech-dispatcher_log_t;
@@ -133,7 +133,7 @@ interface(`speech-dispatcher_admin',`
 	logging_search_logs($1)
 	admin_pattern($1, speech-dispatcher_log_t)
 
-	speech-dispatcher_systemctl($1)
+	speech_dispatcher_systemctl($1)
 	admin_pattern($1, speech-dispatcher_unit_file_t)
 	allow $1 speech-dispatcher_unit_file_t:service all_service_perms;
 	optional_policy(`


### PR DESCRIPTION
I've tested this:

```
$ cat tst.te
policy_module(tst, 1.0.0)

require {
    type httpd_t;
}

speech-dispatcher_admin(httpd_t)
#speech_dispatcher_admin(httpd_t)
$ make -f /usr/share/selinux/devel/Makefile tst.pp
...
Compiling targeted tst module
tst.te:7:ERROR 'syntax error' at token 'speech-dispatcher_admin' on line 3331:

speech-dispatcher_admin(httpd_t)
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [/usr/share/selinux/devel/include/Makefile:157: tmp/tst.mod] Error 1
```

With patch:

```
$ cat tst.te
policy_module(tst, 1.0.0)

require {
    type httpd_t;
}

#speech-dispatcher_admin(httpd_t)
speech_dispatcher_admin(httpd_t)
$ make -f /usr/share/selinux/devel/Makefile tst.pp
Compiling targeted tst module
Creating targeted tst.pp policy package
rm tmp/tst.mod.fc tmp/tst.mod
```