### PR TITLE
Dontaudit net_admin capability for confined users dbusd type

### DIFF
--- a/dbus.if
+++ b/dbus.if
@@ -115,6 +115,8 @@ template(`dbus_role_template',`
 
 	logging_send_syslog_msg($1_dbusd_t)
 
+	dontaudit $1_dbusd_t self:capability net_admin;
+
 	optional_policy(`
 		mozilla_domtrans_spec($1_dbusd_t, $1_t)
 	')


### PR DESCRIPTION
The rule has been moved from sysadm.te to dbus.if/dbus_role_template
to support the suggested resolution of BZ(1703241)