### PR TITLE
cockpit: Support split-out TLS proxy

### DIFF
--- a/cockpit.fc
+++ b/cockpit.fc
@@ -4,6 +4,7 @@
 /etc/systemd/system/cockpit.*	--	gen_context(system_u:object_r:cockpit_unit_file_t,s0)
 
 /usr/libexec/cockpit-ws		--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+/usr/libexec/cockpit-tls	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
 
 /usr/libexec/cockpit-cert-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 /usr/libexec/cockpit-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)

--- a/cockpit.te
+++ b/cockpit.te
@@ -40,6 +40,9 @@ allow cockpit_ws_t self:tcp_socket create_stream_socket_perms;
 
 kernel_read_system_state(cockpit_ws_t)
 
+# cockpit-tls can execute cockpit-ws
+can_exec(cockpit_ws_t,cockpit_ws_exec_t)
+
 # cockpit-ws can execute cockpit-session
 can_exec(cockpit_ws_t,cockpit_session_exec_t)
 
@@ -93,6 +96,9 @@ allow cockpit_ws_t cockpit_session_t:process signal_perms;
 
 # cockpit-session communicates back with cockpit-ws
 allow cockpit_session_t cockpit_ws_t:unix_stream_socket rw_stream_socket_perms;
+
+# cockpit-tls and cockpit-ws communicate over a Unix socket
+allow cockpit_ws_t cockpit_ws_t:unix_stream_socket { create_stream_socket_perms connectto };
 
 optional_policy(`
     hostname_exec(cockpit_ws_t)


### PR DESCRIPTION
Soon, the TLS termination and client-side certificate handling will be
split out into a new cockpit-tls process. This communicates with
cockpit-ws via a Unix domain socket.

------

Without this, I'm currently getting
```
denied  { connectto } for  pid=6668 comm="cockpit-tls" path="/run/cockpit/tls/ws.8.sock" scontext=system_u:system_r:cockpit_ws_t:s0 tcontext=system_u:system_r:cockpit_ws_t:s0 tclass=unix_stream_socket permissive=0

denied  { execute_no_trans } for  pid=6759 comm="cockpit-tls" path="/usr/libexec/cockpit-ws" dev="dm-0" ino=1505205 scontext=system_u:system_r:cockpit_ws_t:s0 tcontext=system_u:object_r:cockpit_ws_exec_t:s0 tclass=file permissive=0
```

I was testing with this local policy adjustment:
```sh
semanage fcontext -a /usr/libexec/cockpit-tls -t cockpit_ws_exec_t
restorecon /usr/libexec/cockpit-tls

cat <<EOF > /tmp/local.te
module local 1.0;
require {
    type cockpit_ws_t;
    type cockpit_ws_exec_t;
    class unix_stream_socket { create_stream_socket_perms connectto };
    class file { execute_no_trans};
}

allow cockpit_ws_t cockpit_ws_t:unix_stream_socket { create_stream_socket_perms connectto };
allow cockpit_ws_t cockpit_ws_exec_t:file { execute_no_trans };
EOF
checkmodule -M -m -o /tmp/local.mod /tmp/local.te
semodule_package -o /tmp/local.pp -m /tmp/local.mod
semodule -i /tmp/local.pp
```

I haven't yet directly tested this PR (this is rather cumbersome, and I can't do it right now -- I'll be able to on Monday). Does this look reasonable?

Thanks!