### PR TITLE
Create explicit fc rule for mailman executable BZ(1666004)

### DIFF
--- a/mailman.fc
+++ b/mailman.fc
@@ -7,6 +7,7 @@
 /usr/lib/mailman/bin/mm-handler.*	--	gen_context(system_u:object_r:mailman_mail_exec_t,s0)
 /usr/lib/mailman.*/bin/mm-handler.*	--	gen_context(system_u:object_r:mailman_mail_exec_t,s0)
 /usr/lib/mailman.*/cron/.*	--	gen_context(system_u:object_r:mailman_queue_exec_t,s0)
+/usr/lib/mailman/mail/mailman	--	gen_context(system_u:object_r:mailman_mail_exec_t,s0)
 /var/lib/mailman(/.*)?	gen_context(system_u:object_r:mailman_data_t,s0)
 /var/lib/mailman.*/archives(/.*)?	gen_context(system_u:object_r:mailman_archive_t,s0)
 


### PR DESCRIPTION
Confirming the updated policy contains the change:
```

# matchpathcon /usr/lib/mailman/mail/mailman
/usr/lib/mailman/mail/mailman   system_u:object_r:bin_t:s0
# dnf update selinux-policy-*3.14.4-20.200.bz1666004.fc31.noarch
# matchpathcon /usr/lib/mailman/mail/mailman
/usr/lib/mailman/mail/mailman   system_u:object_r:mailman_mail_exec_t:s0
```