### PR TITLE
Replace "-" by "_" in types names

### DIFF
--- a/speech-dispatcher.fc
+++ b/speech-dispatcher.fc
@@ -1,5 +1,5 @@
-/usr/bin/speech-dispatcher		--	gen_context(system_u:object_r:speech-dispatcher_exec_t,s0)
+/usr/bin/speech-dispatcher		--	gen_context(system_u:object_r:speech_dispatcher_exec_t,s0)
 
-/usr/lib/systemd/system/speech-dispatcherd.service		--	gen_context(system_u:object_r:speech-dispatcher_unit_file_t,s0)
+/usr/lib/systemd/system/speech-dispatcherd.service		--	gen_context(system_u:object_r:speech_dispatcher_unit_file_t,s0)
 
-/var/log/speech-dispatcher(/.*)?		gen_context(system_u:object_r:speech-dispatcher_log_t,s0)
+/var/log/speech-dispatcher(/.*)?		gen_context(system_u:object_r:speech_dispatcher_log_t,s0)

--- a/speech-dispatcher.if
+++ b/speech-dispatcher.if
@@ -3,7 +3,7 @@
 
 ########################################
 ## <summary>
-##	Execute speech-dispatcher in the speech-dispatcher domain.
+##	Execute speech-dispatcher in the speech_dispatcher domain.
 ## </summary>
 ## <param name="domain">
 ## <summary>
@@ -13,11 +13,11 @@
 #
 interface(`speech_dispatcher_domtrans',`
 	gen_require(`
-		type speech-dispatcher_t, speech-dispatcher_exec_t;
+		type speech_dispatcher_t, speech_dispatcher_exec_t;
 	')
 
 	corecmd_search_bin($1)
-	domtrans_pattern($1, speech-dispatcher_exec_t, speech-dispatcher_t)
+	domtrans_pattern($1, speech_dispatcher_exec_t, speech_dispatcher_t)
 ')
 ########################################
 ## <summary>
@@ -32,11 +32,11 @@ interface(`speech_dispatcher_domtrans',`
 #
 interface(`speech_dispatcher_read_log',`
 	gen_require(`
-		type speech-dispatcher_log_t;
+		type speech_dispatcher_log_t;
 	')
 
 	logging_search_logs($1)
-	read_files_pattern($1, speech-dispatcher_log_t, speech-dispatcher_log_t)
+	read_files_pattern($1, speech_dispatcher_log_t, speech_dispatcher_log_t)
 ')
 
 ########################################
@@ -51,11 +51,11 @@ interface(`speech_dispatcher_read_log',`
 #
 interface(`speech_dispatcher_append_log',`
 	gen_require(`
-		type speech-dispatcher_log_t;
+		type speech_dispatcher_log_t;
 	')
 
 	logging_search_logs($1)
-	append_files_pattern($1, speech-dispatcher_log_t, speech-dispatcher_log_t)
+	append_files_pattern($1, speech_dispatcher_log_t, speech_dispatcher_log_t)
 ')
 
 ########################################
@@ -70,17 +70,17 @@ interface(`speech_dispatcher_append_log',`
 #
 interface(`speech_dispatcher_manage_log',`
 	gen_require(`
-		type speech-dispatcher_log_t;
+		type speech_dispatcher_log_t;
 	')
 
 	logging_search_logs($1)
-	manage_dirs_pattern($1, speech-dispatcher_log_t, speech-dispatcher_log_t)
-	manage_files_pattern($1, speech-dispatcher_log_t, speech-dispatcher_log_t)
-	manage_lnk_files_pattern($1, speech-dispatcher_log_t, speech-dispatcher_log_t)
+	manage_dirs_pattern($1, speech_dispatcher_log_t, speech_dispatcher_log_t)
+	manage_files_pattern($1, speech_dispatcher_log_t, speech_dispatcher_log_t)
+	manage_lnk_files_pattern($1, speech_dispatcher_log_t, speech_dispatcher_log_t)
 ')
 ########################################
 ## <summary>
-##	Execute speech-dispatcher server in the speech-dispatcher domain.
+##	Execute speech-dispatcher server in the speech_dispatcher domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -90,17 +90,17 @@ interface(`speech_dispatcher_manage_log',`
 #
 interface(`speech_dispatcher_systemctl',`
 	gen_require(`
-		type speech-dispatcher_t;
-		type speech-dispatcher_unit_file_t;
+		type speech_dispatcher_t;
+		type speech_dispatcher_unit_file_t;
 	')
 
 	systemd_exec_systemctl($1)
 	init_reload_services($1)
     systemd_read_fifo_file_passwd_run($1)
-	allow $1 speech-dispatcher_unit_file_t:file read_file_perms;
-	allow $1 speech-dispatcher_unit_file_t:service manage_service_perms;
+	allow $1 speech_dispatcher_unit_file_t:file read_file_perms;
+	allow $1 speech_dispatcher_unit_file_t:service manage_service_perms;
 
-	ps_process_pattern($1, speech-dispatcher_t)
+	ps_process_pattern($1, speech_dispatcher_t)
 ')
 
 
@@ -118,24 +118,24 @@ interface(`speech_dispatcher_systemctl',`
 #
 interface(`speech_dispatcher_admin',`
 	gen_require(`
-		type speech-dispatcher_t;
-		type speech-dispatcher_log_t;
-	    type speech-dispatcher_unit_file_t;
+		type speech_dispatcher_t;
+		type speech_dispatcher_log_t;
+	    type speech_dispatcher_unit_file_t;
 	')
 
-	allow $1 speech-dispatcher_t:process { signal_perms };
-	ps_process_pattern($1, speech-dispatcher_t)
+	allow $1 speech_dispatcher_t:process { signal_perms };
+	ps_process_pattern($1, speech_dispatcher_t)
 
     tunable_policy(`deny_ptrace',`',`
-        allow $1 speech-dispatcher_t:process ptrace;
+        allow $1 speech_dispatcher_t:process ptrace;
     ')
 
 	logging_search_logs($1)
-	admin_pattern($1, speech-dispatcher_log_t)
+	admin_pattern($1, speech_dispatcher_log_t)
 
 	speech_dispatcher_systemctl($1)
-	admin_pattern($1, speech-dispatcher_unit_file_t)
-	allow $1 speech-dispatcher_unit_file_t:service all_service_perms;
+	admin_pattern($1, speech_dispatcher_unit_file_t)
+	allow $1 speech_dispatcher_unit_file_t:service all_service_perms;
 	optional_policy(`
 		systemd_passwd_agent_exec($1)
 		systemd_read_fifo_file_passwd_run($1)

--- a/speech-dispatcher.te
+++ b/speech-dispatcher.te
@@ -5,57 +5,64 @@ policy_module(speech-dispatcher, 1.0.0)
 # Declarations
 #
 
-type speech-dispatcher_t;
-type speech-dispatcher_exec_t;
-init_daemon_domain(speech-dispatcher_t, speech-dispatcher_exec_t)
-application_executable_file(speech-dispatcher_exec_t)
+type speech_dispatcher_t;
+type speech_dispatcher_exec_t;
+typealias speech_dispatcher_t alias speech-dispatcher_t;
+typealias speech_dispatcher_exec_t alias speech-dispatcher_exec_t;
+init_daemon_domain(speech_dispatcher_t, speech_dispatcher_exec_t)
+application_executable_file(speech_dispatcher_exec_t)
 
-type speech-dispatcher_home_t;
-userdom_user_home_content(speech-dispatcher_home_t)
+type speech_dispatcher_home_t;
+typealias speech_dispatcher_home_t alias speech-dispatcher_home_t;
+userdom_user_home_content(speech_dispatcher_home_t)
 
-type speech-dispatcher_log_t;
-logging_log_file(speech-dispatcher_log_t)
+type speech_dispatcher_log_t;
+typealias speech_dispatcher_log_t alias speech-dispatcher_log_t;
+logging_log_file(speech_dispatcher_log_t)
 
-type speech-dispatcher_unit_file_t;
-systemd_unit_file(speech-dispatcher_unit_file_t)
+type speech_dispatcher_unit_file_t;
+typealias speech_dispatcher_unit_file_t alias speech-dispatcher_unit_file_t;
+systemd_unit_file(speech_dispatcher_unit_file_t)
 
-type speech-dispatcher_tmp_t;
-files_tmp_file(speech-dispatcher_tmp_t)
+type speech_dispatcher_tmp_t;
+typealias speech_dispatcher_tmp_t alias speech-dispatcher_tmp_t;
+files_tmp_file(speech_dispatcher_tmp_t)
 
-type speech-dispatcher_tmpfs_t;
-files_tmpfs_file(speech-dispatcher_tmpfs_t)
+type speech_dispatcher_tmpfs_t;
+typealias speech_dispatcher_tmpfs_t alias speech-dispatcher_tmpfs_t;
+files_tmpfs_file(speech_dispatcher_tmpfs_t)
 
 ########################################
 #
 # speech-dispatcher local policy
 #
 
-allow speech-dispatcher_t self:process signal_perms;
+allow speech_dispatcher_t self:process signal_perms;
 
-allow speech-dispatcher_t self:fifo_file rw_fifo_file_perms;
-allow speech-dispatcher_t self:unix_stream_socket create_stream_socket_perms;
-allow speech-dispatcher_t self:tcp_socket create_socket_perms;
+allow speech_dispatcher_t self:fifo_file rw_fifo_file_perms;
+allow speech_dispatcher_t self:unix_stream_socket create_stream_socket_perms;
+allow speech_dispatcher_t self:tcp_socket create_socket_perms;
 
-manage_dirs_pattern(speech-dispatcher_t, speech-dispatcher_log_t, speech-dispatcher_log_t)
-manage_files_pattern(speech-dispatcher_t, speech-dispatcher_log_t, speech-dispatcher_log_t)
-logging_log_filetrans(speech-dispatcher_t, speech-dispatcher_log_t, { dir })
+manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
+manage_files_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
+logging_log_filetrans(speech_dispatcher_t, speech_dispatcher_log_t, { dir })
 
-manage_files_pattern(speech-dispatcher_t, speech-dispatcher_tmp_t, speech-dispatcher_tmp_t)
-files_tmp_filetrans(speech-dispatcher_t, speech-dispatcher_tmp_t, { file })
+manage_files_pattern(speech_dispatcher_t, speech_dispatcher_tmp_t, speech_dispatcher_tmp_t)
+files_tmp_filetrans(speech_dispatcher_t, speech_dispatcher_tmp_t, { file })
 
-manage_files_pattern(speech-dispatcher_t, speech-dispatcher_tmpfs_t, speech-dispatcher_tmpfs_t)
-fs_tmpfs_filetrans(speech-dispatcher_t, speech-dispatcher_tmpfs_t, { file })
+manage_files_pattern(speech_dispatcher_t, speech_dispatcher_tmpfs_t, speech_dispatcher_tmpfs_t)
+fs_tmpfs_filetrans(speech_dispatcher_t, speech_dispatcher_tmpfs_t, { file })
 
-manage_files_pattern(speech-dispatcher_t, speech-dispatcher_home_t, speech-dispatcher_home_t)
-manage_dirs_pattern(speech-dispatcher_t, speech-dispatcher_home_t, speech-dispatcher_home_t)
-manage_fifo_files_pattern(speech-dispatcher_t, speech-dispatcher_home_t, speech-dispatcher_home_t)
-userdom_filetrans_home_content(speech-dispatcher_t,speech-dispatcher_home_t, dir, ".speech-dispatcher")
+manage_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
+manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
+manage_fifo_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
+userdom_filetrans_home_content(speech_dispatcher_t,speech_dispatcher_home_t, dir, ".speech-dispatcher")
 
-kernel_read_system_state(speech-dispatcher_t)
+kernel_read_system_state(speech_dispatcher_t)
 
-auth_read_passwd(speech-dispatcher_t)
+auth_read_passwd(speech_dispatcher_t)
 
-corenet_tcp_connect_pdps_port(speech-dispatcher_t)
+corenet_tcp_connect_pdps_port(speech_dispatcher_t)
 
-dev_read_urand(speech-dispatcher_t)
+dev_read_urand(speech_dispatcher_t)
 


### PR DESCRIPTION
Replace "-" by "_" in all names of the speech-dispatcher.*_t types
as hyphen is not understood by checkmodule when used in a custom policy