### PR TITLE
Allow system_munin_plugin_t read bind stats BZ(1648861)

### DIFF
--- a/munin.te
+++ b/munin.te
@@ -435,7 +435,9 @@ term_getattr_all_ttys(system_munin_plugin_t)
 term_getattr_all_ptys(system_munin_plugin_t)
 
 optional_policy(`
+	bind_exec(system_munin_plugin_t)
 	bind_read_config(system_munin_plugin_t)
+	bind_read_pid_files(system_munin_plugin_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow system_munin_plugin_t read bind/unbound stats
using bind_read_pid_files() and bind_exec() interfaces.

Requires: https://github.com/fedora-selinux/selinux-policy-contrib/pull/120