### PR TITLE
Allow domain transition lsmd_t to sensord_t

### DIFF
--- a/lsm.te
+++ b/lsm.te
@@ -55,6 +55,10 @@ optional_policy(`
     rpm_debuginfo_domtrans(lsmd_t)
 ')
 
+optional_policy(`
+	sensord_domtrans(lsmd_t)
+')
+
 ########################################
 #
 # Local lsmd plugin policy


### PR DESCRIPTION
Add macro sensord_domtrans(lsmd_t) which allow domain transition to sensord_t which
solve problem with bad transition where sensord-service get label lsmd_t because lsm daemon executes sensord
Resolves: rhbz#1662062