### PR TITLE
Allow cyrus work with PrivateTmp

### DIFF
--- a/cyrus.te
+++ b/cyrus.te
@@ -109,6 +109,8 @@ fs_search_auto_mountpoints(cyrus_t)
 
 auth_use_nsswitch(cyrus_t)
 
+init_read_state(cyrus_t)
+
 libs_exec_lib_files(cyrus_t)
 
 logging_send_syslog_msg(cyrus_t)
@@ -150,6 +152,10 @@ optional_policy(`
 	files_dontaudit_write_usr_dirs(cyrus_t)
     snmp_manage_var_lib_files(cyrus_t)
 	snmp_stream_connect(cyrus_t)
+')
+
+optional_policy(`
+	systemd_private_tmp(cyrus_tmp_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Add systemd_private_tmp(cyrus_tmp_t) and init_read_state(cyrus_t)