### PR TITLE
Allow httpd_t to signull mailman_cgi_t process

### DIFF
--- a/apache.te
+++ b/apache.te
@@ -1024,6 +1024,7 @@ optional_policy(`
 
 optional_policy(`
 	mailman_signal_cgi(httpd_t)
+	mailman_signull_cgi(httpd_t)
 	mailman_domtrans_cgi(httpd_t)
 	mailman_read_data_files(httpd_t)
 	# should have separate types for public and private archives

--- a/mailman.if
+++ b/mailman.if
@@ -165,6 +165,24 @@ interface(`mailman_signal_cgi',`
 	allow $1 mailman_cgi_t:process signal;
 ')
 
+########################################
+## <summary>
+##      Send null signals to the mailman cgi domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`mailman_signull_cgi',`
+        gen_require(`
+                type mailman_cgi_t;
+        ')
+
+	allow $1 mailman_cgi_t:process signull;
+')
+
 #######################################
 ## <summary>
 ##	Allow domain to search data directories.


### PR DESCRIPTION
Allow httpd_t to test for existence of mailman_cgi_t process without sending a signal.

Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1686462#

