### PR TITLE
Fix SELinux denial prevents timedatex from starting on a freshly-inslalled system

### DIFF
--- a/timedatex.te
+++ b/timedatex.te
@@ -16,6 +16,8 @@ init_daemon_domain(timedatex_t, timedatex_exec_t)
 allow timedatex_t self:fifo_file rw_fifo_file_perms;
 allow timedatex_t self:unix_stream_socket create_stream_socket_perms;
 
+dev_read_realtime_clock(timedatex_t)
+
 domain_use_interactive_fds(timedatex_t)
 
 files_read_etc_files(timedatex_t)
@@ -23,7 +25,12 @@ files_read_etc_files(timedatex_t)
 miscfiles_read_localization(timedatex_t)
 
 optional_policy(`
+    clock_read_adjtime(timedatex_t)
+')
+
+optional_policy(`
     dbus_read_pid_files(timedatex_t)
+    dbus_send_system_bus(timedatex_t)
     dbus_stream_connect_system_dbusd(timedatex_t)
 ')
 


### PR DESCRIPTION
Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1734197#

Allow timedatex service to read the realtime clock and clock drift adjustments.
Allow timedatex service to send a message on the system DBUS.