### PR TITLE
cockpit: Allow cockpit-session to read cockpit-tls state

### DIFF
--- a/cockpit.te
+++ b/cockpit.te
@@ -142,6 +142,8 @@ manage_dirs_pattern(cockpit_session_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
 manage_files_pattern(cockpit_session_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
 fs_tmpfs_filetrans(cockpit_session_t, cockpit_tmpfs_t, { file })
 
+read_files_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
+
 kernel_read_network_state(cockpit_session_t)
 
 # cockpit-session runs a full pam stack, including pam_selinux.so


### PR DESCRIPTION
Commit 819c407b87 was missing the permission for cockpit-session to read
cockpit-tls' validated certificates in /run/cockpit/tls/.

----

I reworked the old https://github.com/cockpit-project/cockpit/pull/11421 to now run against the new cockpit-tls. Without this, it fails with
```
AVC avc:  denied  { open } for  pid=8136 comm="cockpit-session" path="/run/cockpit/tls/ws.8129.crt" dev="tmpfs" ino=46659 scontext=system_u:system_r:cockpit_session_t:s0 tcontext=system_u:object_r:cockpit_var_run_t:s0 tclass=file permissive=0
AVC avc:  denied  { read } for  pid=11409 comm="cockpit-session" name="ws.11407.crt" dev="tmpfs" ino=72371 scontext=system_u:system_r:cockpit_session_t:s0 tcontext=system_u:object_r:cockpit_var_run_t:s0 tclass=file permissive=0
```