### PR TITLE
Run lldpd service as lldpad_t.

### DIFF
--- a/lldpad.fc
+++ b/lldpad.fc
@@ -1,9 +1,15 @@
 /etc/rc\.d/init\.d/lldpad	--	gen_context(system_u:object_r:lldpad_initrc_exec_t,s0)
 
-/usr/sbin/lldpad	--	gen_context(system_u:object_r:lldpad_exec_t,s0)
+/usr/sbin/lldpad        --	gen_context(system_u:object_r:lldpad_exec_t,s0)
 
-/var/lib/lldpad(/.*)?	gen_context(system_u:object_r:lldpad_var_lib_t,s0)
+/usr/sbin/lldpd         --	gen_context(system_u:object_r:lldpad_exec_t,s0)
 
-/var/run/lldpad.*	gen_context(system_u:object_r:lldpad_var_run_t,s0)
+/var/lib/lldpad(/.*)?		gen_context(system_u:object_r:lldpad_var_lib_t,s0)
 
-/dev/shm/lldpad.*   --  gen_context(system_u:object_r:lldpad_tmpfs_t,s0)
+/var/lib/lldpd(/.*)?		gen_context(system_u:object_r:lldpad_var_lib_t,s0)
+
+/var/run/lldpad.*	--	gen_context(system_u:object_r:lldpad_var_run_t,s0)
+
+/var/run/lldpd.*	--      gen_context(system_u:object_r:lldpad_var_run_t,s0)
+
+/dev/shm/lldpad.*	--	gen_context(system_u:object_r:lldpad_tmpfs_t,s0)

--- a/lldpad.te
+++ b/lldpad.te
@@ -20,16 +20,15 @@ files_type(lldpad_var_lib_t)
 
 type lldpad_var_run_t;
 files_pid_file(lldpad_var_run_t)
-
+systemd_mount_dir(lldpad_var_run_t)
 ########################################
 #
 # Local policy
 #
-
-allow lldpad_t self:capability { net_admin net_raw sys_resource };
+allow lldpad_t self:capability { chown dac_override fowner fsetid kill net_admin net_raw setgid setuid sys_chroot sys_resource };
 allow lldpad_t self:shm create_shm_perms;
 allow lldpad_t self:fifo_file rw_fifo_file_perms;
-allow lldpad_t self:unix_stream_socket { accept listen };
+allow lldpad_t self:unix_stream_socket { accept connectto listen };
 allow lldpad_t self:netlink_route_socket create_netlink_socket_perms;
 allow lldpad_t self:packet_socket create_socket_perms;
 allow lldpad_t self:udp_socket create_socket_perms;
@@ -50,6 +49,10 @@ kernel_read_all_sysctls(lldpad_t)
 kernel_read_network_state(lldpad_t)
 kernel_request_load_module(lldpad_t)
 
+auth_read_passwd(lldpad_t)
+
+corecmd_exec_bin(lldpad_t)
+
 dev_read_sysfs(lldpad_t)
 
 fs_getattr_tmpfs(lldpad_t)
@@ -58,12 +61,21 @@ logging_send_syslog_msg(lldpad_t)
 
 userdom_dgram_send(lldpad_t)
 
+
 optional_policy(`
-	fcoe_dgram_send_fcoemon(lldpad_t)
+    dbus_system_bus_client(lldpad_t)
+')
+
+optional_policy(`
+    fcoe_dgram_send_fcoemon(lldpad_t)
 ')
 
 optional_policy(`
     networkmanager_dgram_send(lldpad_t)
+')
+
+optional_policy(`
+    sysnet_read_config(lldpad_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Added rules for lldpd - a daemon able to receive and send LLDP frames, in lldpad files - a LLDP agent daemon.

Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1726246#