### PR TITLE
networkmanager: allow NetworkManager_t to create bluetooth_socket

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -79,6 +79,10 @@ allow NetworkManager_t self:packet_socket create_socket_perms;
 allow NetworkManager_t self:rawip_socket create_socket_perms;
 allow NetworkManager_t self:socket create_socket_perms;
 
+tunable_policy(`deny_bluetooth',`',`
+    allow NetworkManager_t self:bluetooth_socket create_stream_socket_perms;
+')
+
 allow NetworkManager_t wpa_cli_t:unix_dgram_socket sendto;
 
 can_exec(NetworkManager_t, NetworkManager_exec_t)


### PR DESCRIPTION
For DUN bluetooth profiles, NetworkManager needs to establish the connection
by creating and connecting an AF_BLUETOOTH socket (see code on current
master [1]). Allow that.

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/6cf28fe2c0b1969a785c687bc3646d60cfce49e1/src/devices/bluetooth/nm-bluez5-dun.c#L66

See-also: https://bugzilla.redhat.com/show_bug.cgi?id=1747768