### PR TITLE
Allow zabbix_t domain to manage zabbix_var_lib_t sock files and connect to unix_stream_socket

### DIFF
--- a/zabbix.te
+++ b/zabbix.te
@@ -100,10 +100,12 @@ dev_read_urand(zabbix_domain)
 
 allow zabbix_t self:capability { dac_read_search  };
 allow zabbix_t self:process { setrlimit };
+allow zabbix_t self:unix_stream_socket connectto;
 
 manage_dirs_pattern(zabbix_t, zabbix_var_lib_t, zabbix_var_lib_t)
 manage_files_pattern(zabbix_t, zabbix_var_lib_t, zabbix_var_lib_t)
 manage_lnk_files_pattern(zabbix_t, zabbix_var_lib_t, zabbix_var_lib_t)
+manage_sock_files_pattern(zabbix_t, zabbix_var_lib_t, zabbix_var_lib_t)
 files_var_lib_filetrans(zabbix_t, zabbix_var_lib_t, dir, "zabbixsrv")
 
 manage_dirs_pattern(zabbix_t, zabbix_log_t, zabbix_log_t)


### PR DESCRIPTION
Added rules for Zabbix - software that monitors numerous parameters of a network and the health and integrity of servers.