### PR TITLE
Allow amanda_t to manage its var lib files and read random_device_t

### DIFF
--- a/amanda.fc
+++ b/amanda.fc
@@ -26,5 +26,7 @@
 /var/lib/amanda/gnutar-lists(/.*)?	gen_context(system_u:object_r:amanda_gnutarlists_t,s0)
 # the null string in here because index is a m4 builtin function
 /var/lib/amanda/[^/]+/index`'(/.*)?	gen_context(system_u:object_r:amanda_var_lib_t,s0)
+/var/lib/amanda(/.*)?               	gen_context(system_u:object_r:amanda_var_lib_t,s0)
+
 
 /var/log/amanda(/.*)?	gen_context(system_u:object_r:amanda_log_t,s0)

--- a/amanda.te
+++ b/amanda.te
@@ -88,7 +88,7 @@ allow amanda_t amanda_gnutarlists_t:lnk_file manage_lnk_file_perms;
 
 manage_dirs_pattern(amanda_t, amanda_var_lib_t, amanda_var_lib_t)
 manage_files_pattern(amanda_t, amanda_var_lib_t, amanda_var_lib_t)
-files_var_lib_filetrans(amanda_t, amanda_var_lib_t, dir)
+files_var_lib_filetrans(amanda_t, amanda_var_lib_t, { dir file })
 
 manage_files_pattern(amanda_t, amanda_log_t, amanda_log_t)
 manage_dirs_pattern(amanda_t, amanda_log_t, amanda_log_t)
@@ -131,6 +131,7 @@ corenet_dontaudit_tcp_bind_all_ports(amanda_t)
 dev_getattr_all_blk_files(amanda_t)
 dev_getattr_all_chr_files(amanda_t)
 dev_read_urand(amanda_t)
+dev_read_rand(amanda_t)
 
 files_read_etc_runtime_files(amanda_t)
 files_list_all(amanda_t)


### PR DESCRIPTION
Amanda - a backup solution that allows the IT administrator to set up a single master backup server to back up multiple hosts over network to tape drives/changers or disks or optical media.

$  rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.noarch

$ sesearch -A -s amanda_t -t random_device_t -c chr_file

$ sesearch -T -s amanda_t -t var_lib_t
type_transition amanda_t var_lib_t:dir amanda_var_lib_t;

Scratch build installed

$ rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.100.noarch

$ sesearch -A -s amanda_t -t random_device_t -c chr_file
allow amanda_t random_device_t:chr_file { getattr ioctl lock open read };

$ sesearch -T -s amanda_t -t var_lib_t
type_transition amanda_t var_lib_t:dir amanda_var_lib_t;
type_transition amanda_t var_lib_t:file amanda_var_lib_t;