### PR TITLE
Fix abrt_upload_watch_t in abrt policy

### DIFF
--- a/abrt.te
+++ b/abrt.te
@@ -631,6 +631,7 @@ tunable_policy(`abrt_upload_watch_anon_write',`
 #
 
 allow abrt_upload_watch_t self:capability { dac_read_search  chown fsetid };
+allow abrt_upload_watch_t self:unix_dgram_socket create_socket_perms;
 
 manage_files_pattern(abrt_upload_watch_t, abrt_upload_watch_tmp_t, abrt_upload_watch_tmp_t)
 manage_dirs_pattern(abrt_upload_watch_t, abrt_upload_watch_tmp_t, abrt_upload_watch_tmp_t)
@@ -659,6 +660,10 @@ tunable_policy(`abrt_upload_watch_anon_write',`
 
 optional_policy(`
     dbus_system_bus_client(abrt_upload_watch_t)
+')
+
+optional_policy(`
+    gnome_list_home_config(abrt_upload_watch_t)
 ')
 
 #######################################


### PR DESCRIPTION
allow abrt_upload_watch_t to create and use its unix datagram socket
allow abrt_upload_watch_t list gnome homedir content (.config)

Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1737419

$  rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.100.noarch

$ sesearch -A -s abrt_upload_watch_t -t abrt_upload_watch_t -c unix_dgram_socket

$ sesearch -A -s abrt_upload_watch_t -t config_home_t

Scratch build installed

$ rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.200.noarch

$ sesearch -A -s abrt_upload_watch_t -t abrt_upload_watch_t -c unix_dgram_socket
allow abrt_upload_watch_t abrt_upload_watch_t:unix_dgram_socket { append bind connect create getattr getopt ioctl lock read setattr setopt shutdown write };

$ sesearch -A -s abrt_upload_watch_t -t config_home_t
allow abrt_upload_watch_t config_home_t:dir { getattr ioctl lock open read search };