### PR TITLE
Label libvirt drivers as virtd_exec_t

### DIFF
--- a/virt.fc
+++ b/virt.fc
@@ -39,6 +39,18 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/sbin/xl		--	gen_context(system_u:object_r:virsh_exec_t,s0)
 /usr/sbin/xm		--	gen_context(system_u:object_r:virsh_exec_t,s0)
 
+/usr/sbin/virtinterfaced	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtlxcd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtnetworkd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtnodedevd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtnwfilterd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtqemud	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtsecretd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtstoraged	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtvboxd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtvzd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtxend	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+
 /var/cache/libvirt(/.*)?	gen_context(system_u:object_r:virt_cache_t,s0-mls_systemhigh)
 
 /var/lib/libvirt(/.*)?		gen_context(system_u:object_r:virt_var_lib_t,s0)


### PR DESCRIPTION
Labeled binaries as virtd_exec_t:
/usr/sbin/virtinterfaced
/usr/sbin/virtlxcd
/usr/sbin/virtnetworkd
/usr/sbin/virtnodedevd
/usr/sbin/virtnwfilterd
/usr/sbin/virtqemud
/usr/sbin/virtsecretd
/usr/sbin/virtstoraged
/usr/sbin/virtvboxd
/usr/sbin/virtvzd
/usr/sbin/virtxend

Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1745076

$ rpm -q selinux-policy
selinux-policy-3.14.4-31.fc32.noarch

$ ls -Z /usr/sbin | grep virt
system_u:object_r:bin_t:s0 virtinterfaced
system_u:object_r:bin_t:s0 virtlxcd
system_u:object_r:bin_t:s0 virtnetworkd
system_u:object_r:bin_t:s0 virtnodedevd
system_u:object_r:bin_t:s0 virtnwfilterd
system_u:object_r:bin_t:s0 virtqemud
system_u:object_r:bin_t:s0 virtsecretd
system_u:object_r:bin_t:s0 virtstoraged
system_u:object_r:bin_t:s0 virtvboxd
system_u:object_r:bin_t:s0 virtxend

Scratch build installed 

$ rpm -q selinux-policy
selinux-policy-3.14.5-3.fc32.100.noarch

$ ls -Z /usr/sbin | grep virt
system_u:object_r:virtd_exec_t:s0 virtinterfaced
system_u:object_r:virtd_exec_t:s0 virtlxcd
system_u:object_r:virtd_exec_t:s0 virtnetworkd
system_u:object_r:virtd_exec_t:s0 virtnodedevd
system_u:object_r:virtd_exec_t:s0 virtnwfilterd
system_u:object_r:virtd_exec_t:s0 virtqemud
system_u:object_r:virtd_exec_t:s0 virtsecretd
system_u:object_r:virtd_exec_t:s0 virtstoraged
system_u:object_r:virtd_exec_t:s0 virtvboxd
system_u:object_r:virtd_exec_t:s0 virtxend
