### PR TITLE
Update timedatex SELinux policy to to sychronizate time with GNOME

### DIFF
--- a/chronyd.if
+++ b/chronyd.if
@@ -291,6 +291,24 @@ interface(`chronyd_admin',`
 	allow $1 chronyd_unit_file_t:service all_service_perms;
 ')
 
+#######################################
+## <summary>
+##  Get chronyd service status
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed to transition.
+##  </summary>
+## </param>
+#
+interface(`chronyd_service_status',`
+    gen_require(`
+        type chronyd_unit_file_t;
+    ')
+
+        allow $1 chronyd_unit_file_t:service status;
+')
+
 ########################################
 ## <summary>
 ##	Execute chronyc in the chronyc domain.

--- a/timedatex.te
+++ b/timedatex.te
@@ -22,8 +22,16 @@ domain_use_interactive_fds(timedatex_t)
 
 files_read_etc_files(timedatex_t)
 
+init_status(timedatex_t)
+
 miscfiles_manage_localization(timedatex_t)
 miscfiles_etc_filetrans_localization(timedatex_t)
+
+systemd_timedated_status(timedatex_t)
+
+optional_policy(`
+    chronyd_service_status(timedatex_t)
+')
 
 optional_policy(`
     clock_read_adjtime(timedatex_t)
@@ -38,4 +46,3 @@ optional_policy(`
 
     policykit_dbus_chat(timedatex_t)
 ')
-


### PR DESCRIPTION
Update timedatex SELinux policy to to sychronizate time with GNOME and add new macro chronyd_service_status to chr
onyd.if
    
    Allow timedatex_t domain to get the status information from systemd
    Allow timedatex_t domain to get status information from chronyd service
    Allow timedatex_t domain to get status information from timedated service
    Add new macro chronyd_service_status to chronyd.if to get chronyd service status


Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1750036

$ rpm -q selinux-policy

selinux-policy-3.14.4-31.fc31.noarch

$ sesearch -A -s timedatex_t -t systemd_timedated_unit_file_t 

$ sesearch -A -s timedatex_t -t init_t  

Scratch build installed

$ rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.100.noarch

$ sesearch -A -s timedatex_t -t systemd_timedated_unit_file_t 

allow timedatex_t systemd_unit_file_type:system status;
$ sesearch -A -s timedatex_t -t init_t  

allow timedatex_t init_t:service status;

allow timedatex_t init_t:system status;