### PR TITLE
Allow avahi_t to send msg to lpr_t

### DIFF
--- a/lpd.te
+++ b/lpd.te
@@ -278,6 +278,10 @@ tunable_policy(`use_lpd_server',`
 userdom_home_reader(lpr_t)
 
 optional_policy(`
+        avahi_dbus_chat(lpr_t)
+')
+
+optional_policy(`
 	cups_read_config(lpr_t)
 	cups_stream_connect(lpr_t)
 	cups_read_pid_files(lpr_t)


### PR DESCRIPTION
Send and receive messages from Avahi, zero-configuration networking implementation, over dbus with Line Printer Deamon protocol-network printing protocol for submitting print jobs to a remote printer.

Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1752843

$ rpm -q selinux-policy
selinux-policy-3.14.3-4.el8.noarch

$ sesearch -A -s avahi_t -t lpr_t -c dbus

Scratch build installed

$ rpm -q selinux-policy
selinux-policy-3.14.3-20.el8.100.noarch

$ sesearch -A -s avahi_t -t lpr_t -c dbus
allow avahi_t lpr_t:dbus send_msg;