### PR TITLE
Update webalizer_t SELinux policy

### DIFF
--- a/webalizer.te
+++ b/webalizer.te
@@ -80,11 +80,17 @@ userdom_use_inherited_user_terminals(webalizer_t)
 userdom_use_unpriv_users_fds(webalizer_t)
 userdom_dontaudit_search_user_home_content(webalizer_t)
 
+dev_list_sysfs(webalizer_t)
+
 optional_policy(`
 	apache_read_log(webalizer_t)
 	apache_content_template(webalizer)
 	apache_content_alias_template(webalizer, webalizer)
 	apache_manage_sys_content(webalizer_t)
+
+	manage_dirs_pattern(webalizer_t,webalizer_rw_content_t,webalizer_rw_content_t)
+	manage_files_pattern(webalizer_t,webalizer_rw_content_t,webalizer_rw_content_t)
+	manage_lnk_files_pattern(webalizer_t,webalizer_rw_content_t,webalizer_rw_content_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow processes labeled as webalizer_t to list sysfs_t files.
Allow processes labeled as webalizer_t to read/write webalizer_rw_content_t  files.
https://bugzilla.redhat.com/show_bug.cgi?id=1753292