### PR TITLE
Run ipa-custodia as ipa_custodia_t

### DIFF
--- a/apache.if
+++ b/apache.if
@@ -1832,6 +1832,27 @@ interface(`apache_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Manage apache pid objects.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_manage_pid_files',`
+	gen_require(`
+		type httpd_var_run_t;
+	')
+
+	files_search_pids($1)
+	manage_dirs_pattern($1, httpd_var_run_t, httpd_var_run_t)
+	manage_files_pattern($1, httpd_var_run_t, httpd_var_run_t)
+	manage_sock_files_pattern($1, httpd_var_run_t, httpd_var_run_t)
+')
+
+########################################
+## <summary>
 ##      Send and receive messages from
 ##      httpd over dbus.
 ## </summary>

--- a/apache.te
+++ b/apache.te
@@ -994,6 +994,7 @@ optional_policy(`
 optional_policy(`
     ipa_read_lib(httpd_t)
     ipa_manage_pid_files(httpd_t)
+    ipa_custodia_stream_connect(httpd_t)
 ')
 
 optional_policy(`

--- a/ipa_custodia.fc
+++ b/ipa_custodia.fc
@@ -1,0 +1,7 @@
+/usr/libexec/ipa/ipa-custodia					--	gen_context(system_u:object_r:ipa_custodia_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-dmldap			--	gen_context(system_u:object_r:ipa_custodia_dmldap_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-pki-tomcat		--	gen_context(system_u:object_r:ipa_custodia_pki_tomcat_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-pki-tomcat-wrapped	--	gen_context(system_u:object_r:ipa_custodia_pki_tomcat_exec_t,s0)
+/usr/libexec/ipa/custodia/ipa-custodia-ra-agent			--	gen_context(system_u:object_r:ipa_custodia_ra_agent_exec_t,s0)
+
+/var/log/ipa-custodia.audit.log(/.*)?				--	gen_context(system_u:object_r:ipa_custodia_log_t,s0)

--- a/ipa_custodia.if
+++ b/ipa_custodia.if
@@ -1,0 +1,60 @@
+
+## <summary>policy for ipa_custodia</summary>
+
+########################################
+## <summary>
+##	Execute ipa_custodia_exec_t in the ipa_custodia domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`ipa_custodia_domtrans',`
+	gen_require(`
+		type ipa_custodia_t, ipa_custodia_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, ipa_custodia_exec_t, ipa_custodia_t)
+')
+
+######################################
+## <summary>
+##	Execute ipa_custodia in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_custodia_exec',`
+	gen_require(`
+		type ipa_custodia_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, ipa_custodia_exec_t)
+')
+
+#####################################
+## <summary>
+##	Connect to ipa_custodia with a unix
+##	domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipa_custodia_stream_connect',`
+	gen_require(`
+		type ipa_custodia_t, ipa_custodia_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, ipa_custodia_var_run_t, ipa_custodia_var_run_t, ipa_custodia_t)
+')

--- a/ipa_custodia.te
+++ b/ipa_custodia.te
@@ -1,0 +1,99 @@
+policy_module(ipa_custodia, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type ipa_custodia_t;
+type ipa_custodia_exec_t;
+init_daemon_domain(ipa_custodia_t, ipa_custodia_exec_t)
+
+type ipa_custodia_dmldap_exec_t;
+init_script_file(ipa_custodia_dmldap_exec_t)
+
+type ipa_custodia_pki_tomcat_exec_t;
+init_script_file(ipa_custodia_pki_tomcat_exec_t)
+
+type ipa_custodia_ra_agent_exec_t;
+init_script_file(ipa_custodia_ra_agent_exec_t)
+
+type ipa_custodia_log_t;
+logging_log_file(ipa_custodia_log_t)
+
+type ipa_custodia_tmp_t;
+files_tmp_file(ipa_custodia_tmp_t)
+
+########################################
+#
+# ipa_custodia local policy
+#
+allow ipa_custodia_t self:capability { setgid setuid };
+allow ipa_custodia_t self:fifo_file rw_fifo_file_perms;
+allow ipa_custodia_t self:unix_stream_socket create_stream_socket_perms;
+allow ipa_custodia_t self:unix_dgram_socket create_socket_perms;
+
+manage_dirs_pattern(ipa_custodia_t,ipa_custodia_log_t,ipa_custodia_log_t)
+manage_files_pattern(ipa_custodia_t, ipa_custodia_log_t, ipa_custodia_log_t)
+logging_log_filetrans(ipa_custodia_t, ipa_custodia_log_t, { dir file })
+
+manage_dirs_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
+manage_files_pattern(ipa_custodia_t, ipa_custodia_tmp_t, ipa_custodia_tmp_t)
+files_tmp_filetrans(ipa_custodia_t, ipa_custodia_tmp_t, { dir file })
+
+kernel_dgram_send(ipa_custodia_t)
+
+auth_read_passwd(ipa_custodia_t)
+
+can_exec(ipa_custodia_t, ipa_custodia_dmldap_exec_t)
+can_exec(ipa_custodia_t, ipa_custodia_pki_tomcat_exec_t)
+can_exec(ipa_custodia_t, ipa_custodia_ra_agent_exec_t)
+
+corecmd_exec_bin(ipa_custodia_t)
+corecmd_mmap_bin_files(ipa_custodia_t)
+
+domain_use_interactive_fds(ipa_custodia_t)
+
+files_mmap_usr_files(ipa_custodia_t)
+
+fs_getattr_xattr_fs(ipa_custodia_t)
+
+files_read_etc_files(ipa_custodia_t)
+
+libs_exec_ldconfig(ipa_custodia_t)
+libs_ldconfig_exec_entry_type(ipa_custodia_t)
+
+miscfiles_read_generic_certs(ipa_custodia_t)
+miscfiles_read_localization(ipa_custodia_t)
+
+sysnet_read_config(ipa_custodia_t)
+
+optional_policy(`
+	apache_search_config(ipa_custodia_t)
+	apache_systemctl(ipa_custodia_t)
+	apache_manage_pid_files(ipa_custodia_t)
+')
+
+optional_policy(`
+	dirsrv_manage_var_run(ipa_custodia_t)
+	dirsrv_stream_connect(ipa_custodia_t)
+')
+
+optional_policy(`
+	ipa_read_lib(ipa_custodia_t)
+	ipa_search_lib(ipa_custodia_t)
+')
+
+optional_policy(`
+	pki_manage_tomcat_etc_rw(ipa_custodia_t)
+	pki_read_tomcat_cert(ipa_custodia_t)
+	pki_rw_tomcat_cert(ipa_custodia_t)
+')
+
+optional_policy(`
+	sssd_read_public_files(ipa_custodia_t)
+	sssd_run_stream_connect(ipa_custodia_t)
+	sssd_search_lib(ipa_custodia_t)
+	sssd_stream_connect(ipa_custodia_t)
+')
+


### PR DESCRIPTION
Create policy files and rules for ipa-custodia service.
ipa-custodia is a helper service for FreeIPA to share secrets between
IPA servers.

Co-Authored-By: Lukas Vrabec <lvrabec@redhat.com>