### PR TITLE
Allow bitlbee_t domain map files in /usr

### DIFF
--- a/bitlbee.te
+++ b/bitlbee.te
@@ -123,6 +123,8 @@ auth_use_nsswitch(bitlbee_t)
 
 logging_send_syslog_msg(bitlbee_t)
 
+files_mmap_usr_files(bitlbee_t)
+
 optional_policy(`
     dbus_system_bus_client(bitlbee_t)
 ')


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1755828

Signed-off-by: Richard Filo <rfilo@redhat.com>