### PR TITLE
Allow stratisd to getattr of fixed disk device nodes

### DIFF
--- a/stratisd.te
+++ b/stratisd.te
@@ -29,6 +29,7 @@ files_pid_filetrans(stratisd_t, stratisd_var_run_t, { dir file lnk_file })
 dev_read_lvm_control(stratisd_t)
 dev_read_sysfs(stratisd_t)
 
+storage_getattr_fixed_disk_dev(stratisd_t)
 storage_raw_read_removable_device(stratisd_t)
 
 optional_policy(`       


### PR DESCRIPTION
Allow stratisd, a daemon that manages a pool of block devices to create flexible filesystems, to get the attributes of fixed disk device nodes.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1755396

$ rpm -q selinux-policy 
selinux-policy-3.14.5-3.fc32.10.noarch

$ sesearch -A -s stratisd_t -t fixed_disk_device_t

Scratch build installed

$ rpm -q selinux-policy 
selinux-policy-3.14.5-3.fc32.11.noarch

$ sesearch -A -s stratisd_t -t fixed_disk_device_t
allow stratisd_t fixed_disk_device_t:blk_file getattr;
