### PR TITLE
Allow dkim to execute sendmail

### DIFF
--- a/milter.te
+++ b/milter.te
@@ -84,6 +84,10 @@ auth_use_nsswitch(dkim_milter_t)
 
 sysnet_dns_name_resolve(dkim_milter_t)
 
+optional_policy(`
+        mta_sendmail_exec(dkim_milter_t)
+')
+
 ########################################
 #
 # milter-greylist local policy


### PR DESCRIPTION
Allow DomainKeys Identified Mail, an email authentication method, to execute Sendmail.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1757950