### PR TITLE
Allow setroubleshoot_fixit_t to read random_device_t

### DIFF
--- a/setroubleshoot.te
+++ b/setroubleshoot.te
@@ -217,6 +217,7 @@ corecmd_exec_bin(setroubleshoot_fixit_t)
 corecmd_exec_shell(setroubleshoot_fixit_t)
 corecmd_getattr_all_executables(setroubleshoot_fixit_t)
 
+dev_read_rand(setroubleshoot_fixit_t)
 dev_read_sysfs(setroubleshoot_fixit_t)
 dev_read_urand(setroubleshoot_fixit_t)
 


### PR DESCRIPTION
Allow setroubleshoot_fixit_t to to read from random number generator devices

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1622115

$ rpm -q selinux-policy
selinux-policy-3.14.5-3.fc32.14.noarch

$ sesearch -A -s setroubleshoot_fixit_t -t random_device_t -c chr_file 

Scratch build installed

$ rpm -q selinux-policy
selinux-policy-3.14.5-3.fc32.15.noarch

$ sesearch -A -s setroubleshoot_fixit_t -t random_device_t -c chr_file -p read
allow setroubleshoot_fixit_t random_device_t:chr_file { getattr ioctl lock open read };