### PR TITLE
Update allow rules set for pads_t domain

### DIFF
--- a/pads.te
+++ b/pads.te
@@ -26,10 +26,12 @@ files_pid_file(pads_var_run_t)
 
 allow pads_t self:capability { dac_read_search   net_raw };
 allow pads_t self:netlink_route_socket create_netlink_socket_perms;
-allow pads_t self:packet_socket create_socket_perms;
+allow pads_t self:packet_socket { map create_socket_perms };
 allow pads_t self:socket create_socket_perms;
 allow pads_t self:udp_socket create_socket_perms;
 allow pads_t self:unix_dgram_socket create_socket_perms;
+allow pads_t self:bluetooth_socket create_socket_perms;
+allow pads_t self:netlink_netfilter_socket create_socket_perms;
 
 allow pads_t pads_config_t:file manage_file_perms;
 files_etc_filetrans(pads_t, pads_config_t, file)


### PR DESCRIPTION
Allow pads_t domain map packet sockets labled pads_t
Allow pads_t domain create netlink netfilter sockets and bluetooth sockets labled pads_t
Allow pads_t domain get and set attributes via ioctl syscall on bluetooth sockets labled pads_t

Fixes:https://bugzilla.redhat.com/show_bug.cgi?id=1757043

Signed-off-by: Richard Filo<rfilo@redhat.com>