### PR TITLE
Allow ipmievd_t to RW watchdog devices

### DIFF
--- a/ipmievd.te
+++ b/ipmievd.te
@@ -47,6 +47,7 @@ corecmd_exec_bin(ipmievd_t)
 dev_manage_ipmi_dev(ipmievd_t)
 dev_filetrans_ipmi(ipmievd_t)
 dev_read_sysfs(ipmievd_t)
+dev_rw_watchdog(ipmievd_t)
 
 files_read_kernel_modules(ipmievd_t)
 files_map_kernel_modules(ipmievd_t)


### PR DESCRIPTION
Allow ipmievd - IPMI event daemon for sending events to syslog to read/write to watchdog devices.