### PR TITLE
Update numad policy to allow signull, kill, nice and trace, processes

### DIFF
--- a/numad.te
+++ b/numad.te
@@ -23,7 +23,7 @@ files_pid_file(numad_var_run_t)
 # numad local policy
 #
 
-allow numad_t self:capability sys_ptrace;
+allow numad_t self:capability { kill sys_nice sys_ptrace } ;
 allow numad_t self:fifo_file rw_fifo_file_perms;
 allow numad_t self:msgq create_msgq_perms;
 allow numad_t self:msg { send receive };
@@ -42,6 +42,7 @@ dev_rw_sysfs(numad_t)
 domain_use_interactive_fds(numad_t)
 domain_read_all_domains_state(numad_t)
 domain_setpriority_all_domains(numad_t)
+domain_signull_all_domains(numad_t)
 
 fs_manage_cgroup_dirs(numad_t)
 fs_rw_cgroup_files(numad_t)


### PR DESCRIPTION
Numad is user-level daemon that provides placement advice and process
management for efficient use of CPUs and memory on systems with NUMA topology
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1759561

Allow capability sys_nice set real-time scheduling policies for calling process,
and set scheduling policies and priorities for arbitrary processes
Allow capability sys_ptrace to trace arbitrary processes
Allow capability kill to kill processes
Allow macro domain_signull_all_domains() to send a null signal to all domains