### PR TITLE
Allow nagios_script_t domain list files labled sysfs_t.

### DIFF
--- a/nagios.te
+++ b/nagios.te
@@ -303,6 +303,8 @@ optional_policy(`
 	files_read_etc_runtime_files(nagios_script_t)
 	files_read_kernel_symbol_table(nagios_script_t)
 
+	dev_list_sysfs(nagios_script_t)
+
 	logging_send_syslog_msg(nagios_script_t)
 ')
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1760883