### PR TITLE
Update timedatex policy to add macros, more detail below

### DIFF
--- a/timedatex.te
+++ b/timedatex.te
@@ -13,10 +13,11 @@ init_daemon_domain(timedatex_t, timedatex_exec_t)
 #
 # timedatex local policy
 #
+allow timedatex_t self:capability sys_time;
 allow timedatex_t self:fifo_file rw_fifo_file_perms;
 allow timedatex_t self:unix_stream_socket create_stream_socket_perms;
 
-dev_read_realtime_clock(timedatex_t)
+corenet_tcp_connect_time_port(timedatex_t)
 
 domain_use_interactive_fds(timedatex_t)
 
@@ -24,9 +25,10 @@ files_read_etc_files(timedatex_t)
 
 miscfiles_manage_localization(timedatex_t)
 miscfiles_etc_filetrans_localization(timedatex_t)
+miscfiles_relabel_localization(timedatex_t)
 
 optional_policy(`
-    clock_read_adjtime(timedatex_t)
+    clock_domtrans(timedatex_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Bugzillas:
https://bugzilla.redhat.com/show_bug.cgi?id=1753239
https://bugzilla.redhat.com/show_bug.cgi?id=1754800
https://bugzilla.redhat.com/show_bug.cgi?id=1754397

Allow capability sys_time to set system clock and real-time (hardware) clock
Allow macro corenet_tcp_connect_time_port to send and receive TCP network traffic in timedatex_t domain
Allow domtrans macro clock_domtrans to execute hwclock in the clock domain
Add macro miscfiles_relabel_localization to allow process to relabel localization info