### PR TITLE
Allow jetty_t domain search and read cgroup_t files.

### DIFF
--- a/jetty.te
+++ b/jetty.te
@@ -59,6 +59,9 @@ manage_dirs_pattern(jetty_t, jetty_var_run_t, jetty_var_run_t)
 manage_files_pattern(jetty_t, jetty_var_run_t, jetty_var_run_t)
 files_pid_filetrans(jetty_t, jetty_var_run_t, dir)
 
+fs_search_cgroup_dirs(jetty_t)
+fs_read_cgroup_files(jetty_t)
+
 kernel_read_system_state(jetty_t)
 kernel_read_network_state(jetty_t)
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1760889