### PR TITLE
Update cockpit policy

### DIFF
--- a/cockpit.te
+++ b/cockpit.te
@@ -8,6 +8,7 @@ policy_module(cockpit, 1.0.0)
 type cockpit_ws_t;
 type cockpit_ws_exec_t;
 init_daemon_domain(cockpit_ws_t,cockpit_ws_exec_t)
+init_nnp_daemon_domain(cockpit_ws_t)
 
 type cockpit_tmp_t;
 files_tmp_file(cockpit_tmp_t)
@@ -17,6 +18,7 @@ userdom_user_tmpfs_file(cockpit_tmpfs_t)
 
 type cockpit_var_run_t;
 files_pid_file(cockpit_var_run_t)
+systemd_mount_dir(cockpit_var_run_t)
 
 type cockpit_unit_file_t;
 systemd_unit_file(cockpit_unit_file_t)


### PR DESCRIPTION
Allow to systemd to use dir with file context cockpit_var_run_t as mount point
Allow SELinux Domain trasition from sytemd into confined domain with NoNewPrivileges
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1761765