### PR TITLE
Allow stratisd to connect to dbus

### DIFF
--- a/stratisd.te
+++ b/stratisd.te
@@ -33,6 +33,7 @@ storage_raw_read_removable_device(stratisd_t)
 
 optional_policy(`       
         dbus_system_bus_client(stratisd_t)
+        dbus_connect_system_bus(stratisd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow stratisd, a daemon that manages a pool of block devices to create flexible filesystems, to connect to the system DBUS for service (acquire_svc).

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1726259