### PR TITLE
Allow capability dac_override in logwatch_mail_t domain 

### DIFF
--- a/logwatch.te
+++ b/logwatch.te
@@ -188,7 +188,7 @@ optional_policy(`
 # Mail local policy
 #
 
-allow logwatch_mail_t self:capability { dac_read_search  };
+allow logwatch_mail_t self:capability { dac_override };
 
 allow logwatch_mail_t logwatch_t:fd use;
 allow logwatch_mail_t logwatch_t:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
Allow capability dac_override in logwatch_mail_t domain, which allow bypass file read, write, and execute permission checks.
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1761072