### PR TITLE
Created dnsmasq_use_ipset boolean

### DIFF
--- a/dnsmasq.te
+++ b/dnsmasq.te
@@ -5,6 +5,13 @@ policy_module(dnsmasq, 1.10.0)
 # Declarations
 #
 
+## <desc>
+##    <p>
+##    Allow the dnsmasq to creating and using netlink_sockets.
+##     </p>
+## </desc>
+gen_tunable(dnsmasq_use_ipset,false)
+
 type dnsmasq_t;
 type dnsmasq_exec_t;
 init_daemon_domain(dnsmasq_t, dnsmasq_exec_t)
@@ -107,6 +114,10 @@ logging_send_syslog_msg(dnsmasq_t)
 
 userdom_dontaudit_use_unpriv_user_fds(dnsmasq_t)
 userdom_dontaudit_search_user_home_dirs(dnsmasq_t)
+
+tunable_policy(`dnsmasq_use_ipset',`
+     allow dnsmasq_t self:netlink_netfilter_socket create_socket_perms;
+')
 
 optional_policy(`
 	cobbler_read_lib_files(dnsmasq_t)


### PR DESCRIPTION
Created boolean to allow the dnsmasq_t domain to creating and using netlink_sockets.
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1742895