### PR TITLE
Added macro for timedatex to chat over dbus.

### DIFF
--- a/timedatex.if
+++ b/timedatex.if
@@ -20,6 +20,27 @@ interface(`timedatex_domtrans',`
 	domtrans_pattern($1, timedatex_exec_t, timedatex_t)
 ')
 
+########################################
+## <summary>
+##      Send and receive messages from
+##      timedatex over dbus.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`timedatex_dbus_chat',`
+	gen_require(`
+		type timedatex_t;
+		class dbus send_msg;
+	')
+
+	allow $1 timedatex_t:dbus send_msg;
+	allow timedatex_t $1:dbus send_msg;
+')
+
 ######################################
 ## <summary>
 ##	Execute timedatex in the caller domain.


### PR DESCRIPTION
Send and receive messages from timedatex over dbus.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1766148

PR for used macro in xserver.te: https://github.com/fedora-selinux/selinux-policy/pull/291
PR for sychronizate time with GNOME: https://github.com/fedora-selinux/selinux-policy-contrib/pull/138