### PR TITLE
cockpit: Support https instance factory

### DIFF
--- a/cockpit.fc
+++ b/cockpit.fc
@@ -5,6 +5,7 @@
 
 /usr/libexec/cockpit-ws		--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
 /usr/libexec/cockpit-tls	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+/usr/libexec/cockpit-wsinstance-factory	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
 
 /usr/libexec/cockpit-cert-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 /usr/libexec/cockpit-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/12972 hardens Cockpit's
web server so that each different client certificate gets handled by its
own cockpit-ws instance. This requires a factory helper that produces
new systemd template instances.

This completes the TLS rework from commit 819c407b8744d25.