### PR TITLE
cockpit: Allow cockpit-session to read cockpit-tls state directory

### DIFF
--- a/cockpit.te
+++ b/cockpit.te
@@ -145,6 +145,7 @@ manage_files_pattern(cockpit_session_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
 fs_tmpfs_filetrans(cockpit_session_t, cockpit_tmpfs_t, { file })
 
 read_files_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
+list_dirs_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
 
 kernel_read_network_state(cockpit_session_t)
 


### PR DESCRIPTION
This is required for the current approach of cockpit-tls exporting one
certificate for every connection, which avoids error prone refcounts.
For that, the PAM module needs to glob for /run/cockpit/tls/<fingerprint>-*.

Resolves: rhbz#1770221