### PR TITLE
cockpit: Drop cockpit-cert-session

### DIFF
--- a/cockpit.fc
+++ b/cockpit.fc
@@ -7,7 +7,6 @@
 /usr/libexec/cockpit-tls	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
 /usr/libexec/cockpit-wsinstance-factory	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
 
-/usr/libexec/cockpit-cert-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 /usr/libexec/cockpit-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 /usr/libexec/cockpit-ssh	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 


### PR DESCRIPTION
This separate binary only existed in a proof of concept, but got dropped
later on (functionality merged into cockpit-session).

This reverts part of commit e5631ccdd200c.