### PR TITLE
Allow NetworkManager_t manage dhcpc_state_t BZ(1770698)

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -424,6 +424,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sysnet_manage_dhcpc_state(NetworkManager_t)
+')
+
+optional_policy(`
 	systemd_write_inhibit_pipes(NetworkManager_t)
 	systemd_read_logind_sessions_files(NetworkManager_t)
 	systemd_dbus_chat_logind(NetworkManager_t)


### PR DESCRIPTION
Allow 11-dhclient running in the NetworkManager_t domain
manage dhcp client state files