### PR TITLE
Allow chronyd to manage NetworkManager PID files

### DIFF
--- a/chronyd.te
+++ b/chronyd.te
@@ -147,6 +147,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+        networkmanager_manage_pid_files(chronyd_t)
+')
+
+optional_policy(`
     virt_read_lib_files(chronyd_t)
 ')
 


### PR DESCRIPTION
Allow chronyd, a daemon for synchronisation of the system clock to manage network management daemon var run files.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1764485

Fix: Allow NetworkManager_t manage dhcpc_state_t 
https://github.com/fedora-selinux/selinux-policy-contrib/pull/164

Fix: Allow networkmanager_t domain domain transition to chronyc_t domain 
https://github.com/fedora-selinux/selinux-policy-contrib/commit/070f96cf0f59735f1d01cb7f9427292b7f112fd3

$ rpm -qa selinux-policy
selinux-policy-3.14.5-15.fc32.noarch

$ sesearch -A -s chronyd_t -t NetworkManager_var_run_t -c file -p write

Scratch build installed:

$ rpm -qa selinux-policy
selinux-policy-3.14.5-15.fc32.100.noarch

$ sesearch -A -s chronyd_t -t NetworkManager_var_run_t -c file -p write
allow chronyd_t NetworkManager_var_run_t:file { append create getattr ioctl link lock open read rename setattr unlink write };
