### PR TITLE
Allow spamd_update_t access antivirus_unit_file_t BZ(1774092)

### DIFF
--- a/antivirus.fc
+++ b/antivirus.fc
@@ -5,6 +5,7 @@
 /etc/rc\.d/init\.d/amavisd-snmp	--	gen_context(system_u:object_r:antivirus_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/clamd.*		--	gen_context(system_u:object_r:antivirus_initrc_exec_t,s0)
 
+/usr/lib/systemd/system/amavisd.*	--	gen_context(system_u:object_r:antivirus_unit_file_t,s0)
 /usr/lib/systemd/system/clamd.*	--	gen_context(system_u:object_r:antivirus_unit_file_t,s0)
 
 /usr/lib/AntiVir/antivir		--	gen_context(system_u:object_r:antivirus_exec_t,s0)

--- a/spamassassin.te
+++ b/spamassassin.te
@@ -646,6 +646,10 @@ userdom_search_admin_dir(spamd_update_t)
 userdom_use_inherited_user_ptys(spamd_update_t)
 
 optional_policy(`
+	antivirus_systemctl(spamd_update_t)
+')
+
+optional_policy(`
 	cron_system_entry(spamd_update_t, spamd_update_exec_t)
 ')
 


### PR DESCRIPTION
Label /usr/lib/systemd/system/amavisd.service as antivirus_unit_file_t.
Allow antivirus_systemctl(spamd_update_t).