### PR TITLE
Label /usr/lib/NetworkManager/dispatcher as NetworkManager_initrc_exec_t

### DIFF
--- a/networkmanager.fc
+++ b/networkmanager.fc
@@ -13,6 +13,7 @@
 /etc/wicd/wireless-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 /etc/wicd/wired-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 
+/usr/lib/NetworkManager/dispatcher\.d(/.*)? gen_context(system_u:object_r:NetworkManager_initrc_exec_t,s0)
 /usr/lib/systemd/system/NetworkManager.* --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 
 /usr/libexec/nm-dispatcher.* --	gen_context(system_u:object_r:NetworkManager_exec_t,s0)


### PR DESCRIPTION
With NetworkManager 1.20 the dispatcher scripts are moved out of /etc to /usr/lib.
https://src.fedoraproject.org/rpms/dhcp/c/b25b19a69ea76e9d11b188a153b4d7214e36b017?branch=master

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1764485

$ rpm -qa selinux-policy
selinux-policy-3.14.5-5.fc32.noarch

$ sudo ls -Z /usr/lib/NetworkManager/ | grep dispatcher
system_u:object_r:lib_t:s0          dispatcher.d  

Scratch build installed

$ rpm -qa selinux-policy
selinux-policy-3.14.5-16.fc32.100.noarch

$ sudo ls -Z /usr/lib/NetworkManager/ | grep dispatcher
system_u:object_r:NetworkManager_initrc_exec_t:s0          dispatcher.d