### PR TITLE
Allow zebra_t domain to read files labled as nsfs_t.

### DIFF
--- a/zebra.te
+++ b/zebra.te
@@ -118,6 +118,7 @@ dev_rw_zero(zebra_t)
 
 fs_getattr_all_fs(zebra_t)
 fs_search_auto_mountpoints(zebra_t)
+fs_read_nsfs_files(zebra_t)
 
 term_list_ptys(zebra_t)
 


### PR DESCRIPTION
Fixes:https://bugzilla.redhat.com/show_bug.cgi?id=1774614