### PR TITLE
Update dkim milter policy to allow use sendmail

### DIFF
--- a/milter.te
+++ b/milter.te
@@ -64,7 +64,7 @@ sysnet_read_config(greylist_milter_t)
 #
 
 allow dkim_milter_t self:capability { kill setgid setuid };
-allow dkim_milter_t self:process signal;
+allow dkim_milter_t self:process { signal setrlimit };
 allow dkim_milter_t self:tcp_socket create_stream_socket_perms;
 allow dkim_milter_t self:unix_stream_socket create_stream_socket_perms;
 
@@ -74,10 +74,13 @@ manage_files_pattern(dkim_milter_t, dkim_milter_tmp_t, dkim_milter_tmp_t)
 manage_dirs_pattern(dkim_milter_t, dkim_milter_tmp_t, dkim_milter_tmp_t)
 files_tmp_filetrans(dkim_milter_t, dkim_milter_tmp_t, { dir file })
 
+fs_getattr_xattr_fs(dkim_milter_t)
+
 kernel_read_kernel_sysctls(dkim_milter_t)
 
 corecmd_exec_shell(dkim_milter_t)
 
+corenet_tcp_connect_smtp_port(dkim_milter_t)
 corenet_udp_bind_all_ports(dkim_milter_t)
 
 auth_use_nsswitch(dkim_milter_t)
@@ -85,7 +88,8 @@ auth_use_nsswitch(dkim_milter_t)
 sysnet_dns_name_resolve(dkim_milter_t)
 
 optional_policy(`
-        mta_sendmail_exec(dkim_milter_t)
+	mta_manage_queue(dkim_milter_t)
+	mta_sendmail_exec(dkim_milter_t)
 ')
 
 ########################################


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1770570
Add macro to allow dkim_milter_t domain to manage mail queue files
in domain mqueue_spool_t
Allow dkim_milter_t domain to set own process resource limit
Allow dkim_milter_t domain to get attributes of filesystem
Allow dkim_milter_t domain to connect simple mail transfer protocol port