### PR TITLE
Allow pulseaudio create .config and dgram sendto to unpriv_userdomain

### DIFF
--- a/pulseaudio.te
+++ b/pulseaudio.te
@@ -99,8 +99,9 @@ auth_use_nsswitch(pulseaudio_t)
 
 logging_send_syslog_msg(pulseaudio_t)
 
+userdom_dgram_send(pulseaudio_t)
+userdom_filetrans_home_content(pulseaudio_t)
 userdom_read_user_tmp_files(pulseaudio_t)
-
 userdom_search_user_home_dirs(pulseaudio_t)
 userdom_write_user_tmp_sockets(pulseaudio_t)
 userdom_manage_user_tmp_files(pulseaudio_t)


### PR DESCRIPTION
Make pulseaudio_t part of userdom_filetrans_type attribute so that it
can create ~/.config directory.
Allow pulseaudio_t send a message to unpriv users
over a unix domain datagram socket.