### PR TITLE
Allow exim to execute bin_t without domain trans

### DIFF
--- a/exim.te
+++ b/exim.te
@@ -107,8 +107,7 @@ kernel_read_kernel_sysctls(exim_t)
 kernel_read_network_state(exim_t)
 kernel_read_system_state(exim_t)
 
-corecmd_search_bin(exim_t)
-corecmd_mmap_bin_files(exim_t)
+corecmd_exec_bin(exim_t)
 
 corenet_all_recvfrom_netlabel(exim_t)
 corenet_tcp_sendrecv_generic_if(exim_t)


### PR DESCRIPTION
Allow exim_t - Mail transfer agent, to execute generic programs in system bin directories (/bin, /sbin, /usr/bin,/usr/sbin) a without domain transition.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1780336