### PR TITLE
Boolean: rngd_t to use executable memory

### DIFF
--- a/rngd.te
+++ b/rngd.te
@@ -1,5 +1,12 @@
 policy_module(rngd, 1.1.0)
 
+## <desc>
+## <p>
+## Allow rngd_t domain to use executable memory
+## </p>
+## </desc>
+gen_tunable(rngd_execmem, false)
+
 ########################################
 #
 # Declarations
@@ -45,6 +52,10 @@ logging_send_syslog_msg(rngd_t)
 miscfiles_read_certs(rngd_t)
 
 term_use_usb_ttys(rngd_t)
+
+tunable_policy(`rngd_execmem',`
+        allow rngd_t self:process { execmem };
+')
 
 optional_policy(`
 	pcscd_stream_connect(rngd_t)


### PR DESCRIPTION
New boolean for rngd_t,daemon that feeds random data from hardware device to kernel, to execute memory.

Fixed bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1697886