### PR TITLE
Allow openfortivpn_t to manage net_conf_t files, introduce boolean openfortivpn_can_network_connect

### DIFF
--- a/openfortivpn.te
+++ b/openfortivpn.te
@@ -44,6 +44,7 @@ can_exec(openfortivpn_t, openfortivpn_exec_t)
 
 # No standard port for SSLVPN
 corenet_all_recvfrom_unlabeled(openfortivpn_t)
+corenet_sendrecv_all_client_packets(openfortivpn_t)
 corenet_tcp_sendrecv_generic_if(openfortivpn_t)
 corenet_tcp_sendrecv_generic_node(openfortivpn_t)
 
@@ -57,10 +58,11 @@ auth_use_nsswitch(openfortivpn_t)
 
 logging_send_syslog_msg(openfortivpn_t)
 
+sysnet_manage_config(openfortivpn_t)
+
 userdom_read_home_certs(openfortivpn_t)
 
 tunable_policy(`openfortivpn_can_network_connect',`
-        corenet_sendrecv_all_client_packets(openfortivpn_t)
         corenet_tcp_connect_all_ports(openfortivpn_t)
         corenet_tcp_sendrecv_all_ports(openfortivpn_t)
 ')

--- a/openfortivpn.te
+++ b/openfortivpn.te
@@ -1,5 +1,13 @@
 policy_module(openfortivpn, 1.0.0)
 
+## <desc>
+##      <p>
+##      Determine whether openfortivpn can
+##      connect to the TCP network.
+##      </p>
+## </desc>
+gen_tunable(openfortivpn_can_network_connect, true)
+
 ########################################
 #
 # Declarations
@@ -36,8 +44,6 @@ can_exec(openfortivpn_t, openfortivpn_exec_t)
 
 # No standard port for SSLVPN
 corenet_all_recvfrom_unlabeled(openfortivpn_t)
-corenet_tcp_connect_all_ports(openfortivpn_t)
-corenet_tcp_sendrecv_all_ports(openfortivpn_t)
 corenet_tcp_sendrecv_generic_if(openfortivpn_t)
 corenet_tcp_sendrecv_generic_node(openfortivpn_t)
 
@@ -52,6 +58,12 @@ auth_use_nsswitch(openfortivpn_t)
 logging_send_syslog_msg(openfortivpn_t)
 
 userdom_read_home_certs(openfortivpn_t)
+
+tunable_policy(`openfortivpn_can_network_connect',`
+        corenet_sendrecv_all_client_packets(openfortivpn_t)
+        corenet_tcp_connect_all_ports(openfortivpn_t)
+        corenet_tcp_sendrecv_all_ports(openfortivpn_t)
+')
 
 optional_policy(`
 	dbus_system_bus_client(openfortivpn_t)


### PR DESCRIPTION
Allow openfortivpn — client for PPP+SSL VPN tunnel services, to manage network config files.

/etc/resolv.conf labeled as net_conf_t is used by openfortivpn for adding DNS name servers.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1787944

Boolean openfortivpn_can_network_connect is by default enabled and determines whether openfortivpn can connect to the TCP network.