### PR TITLE
Stratisd: dac_override cap and new macro to chat over dbus

### DIFF
--- a/stratisd.if
+++ b/stratisd.if
@@ -2,6 +2,27 @@
 
 ########################################
 ## <summary>
+##      Send and receive messages from
+##      stratisd over dbus.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`stratisd_dbus_chat',`
+        gen_require(`
+                type stratisd_t;
+                class dbus send_msg;
+        ')
+
+        allow $1 stratisd_t:dbus send_msg;
+        allow stratisd_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
 ##  Execute stratisd_exec_t in the stratisd domain.
 ## </summary>
 ## <param name="domain">

--- a/stratisd.te
+++ b/stratisd.te
@@ -16,7 +16,7 @@ files_pid_file(stratisd_var_run_t)
 #
 # stratisd local policy
 #
-allow stratisd_t self:capability sys_admin;
+allow stratisd_t self:capability { dac_override sys_admin };
 allow stratisd_t self:fifo_file rw_fifo_file_perms;
 allow stratisd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow stratisd_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
Add dac_override capability to stratisd_t domain.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1765514

Added macro for stratisd to send and receive messages over dbus.