### PR TITLE
Allow opafm_t to create and use netlink rdma sockets.

### DIFF
--- a/opafm.te
+++ b/opafm.te
@@ -23,6 +23,8 @@ files_pid_file(opafm_var_run_t)
 allow opafm_t self:capability dac_read_search;
 allow opafm_t self:process setsched;
 
+allow opafm_t self:netlink_rdma_socket create_socket_perms;
+
 allow opafm_t self:unix_dgram_socket create_stream_socket_perms;
 
 manage_dirs_pattern(opafm_t, opafm_var_lib_t, opafm_var_lib_t)


### PR DESCRIPTION
Allow opafm_t-Intel Omni-Path Fabric Host Software, to create and use netlink_rdma (remote direct memory access) socket.

Intel Omni-Path Fabric Host Software installs components needed to set up compute, I/O, and Service nodes with drivers, stacks, and basic tools for local configuration and monitoring.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1786670