### PR TITLE
Dontaudit domain chronyd_t to list in user home dirs.

### DIFF
--- a/chronyd.te
+++ b/chronyd.te
@@ -112,6 +112,7 @@ corenet_udp_bind_chronyd_port(chronyd_t)
 corenet_udp_sendrecv_chronyd_port(chronyd_t)
 
 domain_dontaudit_getsession_all_domains(chronyd_t)
+userdom_dontaudit_list_user_home_dirs(chronyd_t)
 
 dev_read_rand(chronyd_t)
 dev_read_urand(chronyd_t)


### PR DESCRIPTION
When I was reproducing the scenario from this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1721382, I found different AVC.