### PR TITLE
Dontaudit timedatex_t read file_contexts_t and validate security cont…

### DIFF
--- a/timedatex.te
+++ b/timedatex.te
@@ -31,6 +31,9 @@ miscfiles_manage_localization(timedatex_t)
 miscfiles_etc_filetrans_localization(timedatex_t)
 miscfiles_relabel_localization(timedatex_t)
 
+selinux_dontaudit_validate_context(timedatex_t)
+seutil_dontaudit_read_file_contexts(timedatex_t)
+
 systemd_timedated_status(timedatex_t)
 
 optional_policy(`


### PR DESCRIPTION
Dontaudit timedatex_t read file_contexts_t and validate security contexts

This is a workaround to dismiss unnecessary AVC denials until the
timedatex code is patched.