### PR TITLE
Allow saslauthd_t filetrans variable files for /tmp directory

### DIFF
--- a/sasl.te
+++ b/sasl.te
@@ -97,7 +97,7 @@ tunable_policy(`saslauthd_read_shadow',`
 optional_policy(`
 	kerberos_read_keytab(saslauthd_t)
 	kerberos_manage_host_rcache(saslauthd_t)
-	kerberos_tmp_filetrans_host_rcache(saslauthd_t, "host_0")
+	kerberos_tmp_filetrans_host_rcache(saslauthd_t)
 	kerberos_use(saslauthd_t)
 ')
 


### PR DESCRIPTION
Saslauthd service need create files with variable name in /tmp dir and
have perm to create file only with specific name
Change filetrans macro for domain saslauthd_t, then can create file
with variable names in \tmp dir with label krb5_host_rcache_t
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1769532
Fedora COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1210256/