### PR TITLE
Added apache create log dirs macro

### DIFF
--- a/apache.if
+++ b/apache.if
@@ -895,6 +895,27 @@ interface(`apache_append_log',`
 	append_files_pattern($1, httpd_log_t, httpd_log_t)
 ')
 
+########################################
+## <summary>
+##      Allow the specified domain to create 
+#       apache's log directories.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access
+##      </summary>
+## </param>
+#
+interface(`apache_create_log_dirs',`
+        gen_require(`
+                type httpd_log_t;
+        ')
+
+        create_dirs_pattern($1, httpd_log_t, httpd_log_t)
+        logging_search_logs($1)
+        setattr_dirs_pattern($1, httpd_log_t, httpd_log_t)
+')
+
 #######################################
 ## <summary>
 ##  Allow the specified domain to write


### PR DESCRIPTION
Allow the specified domain to create apache log directories.

Macro applied in init.te: https://github.com/fedora-selinux/selinux-policy/pull/320/commits

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1789868