### PR TITLE
Allow vhostmd communication with hosted virtual machines

### DIFF
--- a/vhostmd.te
+++ b/vhostmd.te
@@ -23,7 +23,7 @@ files_pid_file(vhostmd_var_run_t)
 # Local policy
 #
 
-allow vhostmd_t self:capability { dac_read_search  ipc_lock setuid setgid };
+allow vhostmd_t self:capability { dac_read_search dac_override ipc_lock setuid setgid };
 allow vhostmd_t self:process { setsched getsched signal };
 allow vhostmd_t self:fifo_file rw_fifo_file_perms;
 
@@ -73,10 +73,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+    virt_read_qemu_pid_files(vhostmd_t)
 	virt_read_config(vhostmd_t)
 	virt_stream_connect(vhostmd_t)
+    virt_stream_connect_svirt(vhostmd_t)
 	virt_write_content(vhostmd_t)
-    virt_rw_svirt_image(vhostmd_t)
+	virt_rw_svirt_image(vhostmd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow vhostmd_t domain qemu_read_pid_files(), virt_stream_connect_svirt(),
and virt_write_svirt_image_sock_file().