### PR TITLE
Allow bacula dac_override capability

### DIFF
--- a/bacula.te
+++ b/bacula.te
@@ -49,7 +49,7 @@ application_executable_file(bacula_unconfined_script_exec_t)
 # Local policy
 #
 
-allow bacula_t self:capability { dac_read_search  chown fowner fsetid setgid setuid};
+allow bacula_t self:capability { dac_read_search dac_override chown fowner fsetid setgid setuid};
 allow bacula_t self:process signal;
 allow bacula_t self:fifo_file rw_fifo_file_perms;
 allow bacula_t self:tcp_socket { accept listen };


### PR DESCRIPTION
The dac_override capability is needed to restore permissions and ownership.
Resolves: rhbz#1741609