### PR TITLE
Update policy for NetworkManager_ssh_t

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -449,12 +449,13 @@ optional_policy(`
 
 optional_policy(`
     ssh_basic_client_template(NetworkManager, NetworkManager_t, system_r)
-    ssh_exec(NetworkManager_ssh_t)
-    term_use_generic_ptys(NetworkManager_ssh_t)
     modutils_domtrans_kmod(NetworkManager_ssh_t)
+    corenet_rw_tun_tap_dev(NetworkManager_ssh_t)
     dbus_connect_system_bus(NetworkManager_ssh_t)
     dbus_system_bus_client(NetworkManager_ssh_t)
+    init_rw_stream_sockets(NetworkManager_ssh_t)
     networkmanager_dbus_chat(NetworkManager_ssh_t)
+    sysnet_domtrans_ifconfig(NetworkManager_ssh_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
corenet_rw_tun_tap_dev: Allow NetworkManager_ssh_t to read write tun_tap_device chr_files

init_rw_stream_sockets:  Allow NetworkManager_ssh_t to read/write to init with a unix domain stream sockets.

kernel_search_network_sysctl: Allow NetworkManager_ssh_t to search network sysctl directories

kernel_request_load_module: Allow NetworkManager_ssh_t to request to load kernel module

sysnet_domtrans_ifconfig: Allow NetworkManager_ssh_t to execute ifconfig in the ifconfig domain

t̶e̶r̶m̶_̶u̶s̶e̶_̶p̶t̶m̶x̶:̶ ̶A̶l̶l̶o̶w̶ ̶N̶e̶t̶w̶o̶r̶k̶M̶a̶n̶a̶g̶e̶r̶_̶s̶s̶h̶_̶t̶ ̶t̶o̶ ̶r̶e̶a̶d̶ ̶a̶n̶d̶ ̶w̶r̶i̶t̶e̶ ̶t̶h̶e̶ ̶p̶t̶y̶ ̶m̶u̶l̶t̶i̶p̶l̶e̶x̶o̶r̶ ̶(̶/̶d̶e̶v̶/̶p̶t̶m̶x̶)̶.̶

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1761071