### PR TITLE
Update radiusd policy

### DIFF
--- a/radius.te
+++ b/radius.te
@@ -15,9 +15,11 @@ gen_tunable(radius_use_jit, false)
 type radiusd_t;
 type radiusd_exec_t;
 init_daemon_domain(radiusd_t, radiusd_exec_t)
+init_nnp_daemon_domain(radiusd_t)
 
 type radiusd_etc_t;
 files_config_file(radiusd_etc_t)
+systemd_mount_dir(radiusd_etc_t)
 
 type radiusd_etc_rw_t;
 files_type(radiusd_etc_rw_t)
@@ -27,12 +29,14 @@ init_script_file(radiusd_initrc_exec_t)
 
 type radiusd_log_t;
 logging_log_file(radiusd_log_t)
+systemd_mount_dir(radiusd_log_t)
 
 type radiusd_var_lib_t;
 files_type(radiusd_var_lib_t)
 
 type radiusd_var_run_t;
 files_pid_file(radiusd_var_run_t)
+systemd_mount_dir(radiusd_var_run_t)
 
 type radiusd_unit_file_t;
 systemd_unit_file(radiusd_unit_file_t)


### PR DESCRIPTION
Allow SELinux Domain trasition from systemd into confined domain with NoNewPrivileges

Allow systemd to use dir with file contexts radiusd_etc_t, radiusd_log_t and
radiusd_var_run_t as mount points

Upstream FreeRADIUS systemd unit has NNP and private mount spaces:

NoNewPrivileges=true
RuntimeDirectory=radiusd
PrivateTmp=true
ReadOnlyDirectories=/etc/raddb/
ReadWriteDirectories=/var/log/radius/

Fedora will likely adopt this.