### PR TITLE
Create interface pcscd_signull

### DIFF
--- a/pcscd.if
+++ b/pcscd.if
@@ -87,6 +87,24 @@ interface(`pcscd_manage_pub_pipes',`
 
 ########################################
 ## <summary>
+##	Send signulls to pcscd processes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pcscd_signull',`
+	gen_require(`
+		type pcscd_t;
+	')
+
+	allow $1 pcscd_t:process signull;
+')
+
+########################################
+## <summary>
 ##	Connect to pcscd over an unix
 ##	domain stream socket.
 ## </summary>


### PR DESCRIPTION
Create interface which allows domain to send signulls to PC/SC Smart Card Daemon.

Interface is used to allow system_mail_t to check for existence of processes labeled as pcscd_t: #209

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1780796#