### PR TITLE
Allow system_mail_t to signull pcscd_t

### DIFF
--- a/mta.te
+++ b/mta.te
@@ -323,6 +323,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	pcscd_signull(system_mail_t)
+')
+
+optional_policy(`
 	postfix_domtrans_postdrop(system_mail_t)
 ')
 


### PR DESCRIPTION
Allow system_mail_t to check for existence of processes labeled as pcscd_t

Used new macro: https://github.com/fedora-selinux/selinux-policy-contrib/pull/208

Fixed Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1780796#