### PR TITLE
Revert "Add new file context rabbitmq_conf_t."

### DIFF
--- a/rabbitmq.fc
+++ b/rabbitmq.fc
@@ -9,5 +9,3 @@
 /var/log/rabbitmq(/.*)?	gen_context(system_u:object_r:rabbitmq_var_log_t,s0)
 
 /var/run/rabbitmq(/.*)?	gen_context(system_u:object_r:rabbitmq_var_run_t,s0)
-
-/etc/rabbitmq(/.*)?	gen_context(system_u:object_r:rabbitmq_conf_t,s0)

--- a/rabbitmq.te
+++ b/rabbitmq.te
@@ -32,9 +32,6 @@ files_pid_file(rabbitmq_var_run_t)
 type rabbitmq_tmp_t;
 files_tmp_file(rabbitmq_tmp_t)
 
-type rabbitmq_conf_t;
-files_config_file(rabbitmq_conf_t)
-
 ######################################
 #
 # Rabbitmq local policy
@@ -69,10 +66,6 @@ files_pid_filetrans(rabbitmq_t, rabbitmq_var_run_t, { dir file })
 manage_dirs_pattern(rabbitmq_t, rabbitmq_tmp_t, rabbitmq_tmp_t)
 manage_files_pattern(rabbitmq_t, rabbitmq_tmp_t, rabbitmq_tmp_t)
 files_tmp_filetrans(rabbitmq_t, rabbitmq_tmp_t, { file dir })
-
-manage_dirs_pattern(rabbitmq_t, rabbitmq_conf_t, rabbitmq_conf_t)
-manage_files_pattern(rabbitmq_t, rabbitmq_conf_t, rabbitmq_conf_t)
-files_etc_filetrans(rabbitmq_t, rabbitmq_conf_t, dir)
 
 kernel_dgram_send(rabbitmq_t)
 


### PR DESCRIPTION
Reverts fedora-selinux/selinux-policy-contrib#179

Reason is that I forgot to ask maintainer of rabbitmq if it is expected behavior that a program which rabbitmq server uses, can write to own configuration file.
I create BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1803126.
And now I'm waiting for answer. In the meantime I'm reverting this PR.