### PR TITLE
Allow postfix stream connect to cyrus through runtime socket

### DIFF
--- a/cyrus.if
+++ b/cyrus.if
@@ -61,6 +61,26 @@ interface(`cyrus_stream_connect',`
 
 ########################################
 ## <summary>
+##	Connect to Cyrus using a unix
+##	domain stream socket in the runtime filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cyrus_runtime_stream_connect',`
+	gen_require(`
+		type cyrus_t, cyrus_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, cyrus_var_run_t, cyrus_var_run_t, cyrus_t)
+')
+
+########################################
+## <summary>
 ##	All of the rules required to
 ##	administrate an cyrus environment.
 ## </summary>

--- a/postfix.te
+++ b/postfix.te
@@ -688,6 +688,7 @@ files_search_all_mountpoints(postfix_smtp_t)
 
 optional_policy(`
 	cyrus_stream_connect(postfix_smtp_t)
+	cyrus_runtime_stream_connect(postfix_smtp_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Add cyrus_runtime_stream_connect() interface.
Allow postfix_smtp_t connect to cyrus_t through a socket in the runtime
filesystem using the cyrus_runtime_stream_connect() interface.

Resolves: rhbz#1807443