### PR TITLE
Allow pdns_t domain to map files in /usr

### DIFF
--- a/pdns.te
+++ b/pdns.te
@@ -62,6 +62,8 @@ auth_use_nsswitch(pdns_t)
 
 logging_send_syslog_msg(pdns_t)
 
+files_mmap_usr_files(pdns_t)
+
 
 ########################################
 #


### PR DESCRIPTION
The pdns server wants to map one of p11-kit modules located in /usr.
From the perspective of security it is ok. It should be allowed.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1809078