### PR TITLE
Mark nm-cloud-setup systemd units as NetworkManager_unit_file_t

### DIFF
--- a/networkmanager.fc
+++ b/networkmanager.fc
@@ -15,6 +15,7 @@
 
 /usr/lib/NetworkManager/dispatcher\.d(/.*)? gen_context(system_u:object_r:NetworkManager_initrc_exec_t,s0)
 /usr/lib/systemd/system/NetworkManager.* --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
+/usr/lib/systemd/system/nm-cloud-setup\.(service|timer) --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 
 /usr/libexec/nm-dispatcher.* --	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
 


### PR DESCRIPTION
Mark /usr/lib/systemd/system/nm-cloud-setup\.(service|timer)
as NetworkManager_unit_file_t to support automated adding a secondary ip
to interfaces required in cloud environments.