### PR TITLE
Create geoclue_t domain with init_daemon_domain()

### DIFF
--- a/geoclue.te
+++ b/geoclue.te
@@ -8,6 +8,7 @@ policy_module(geoclue, 1.0.0)
 type geoclue_t;
 type geoclue_exec_t;
 application_domain(geoclue_t, geoclue_exec_t)
+init_daemon_domain(geoclue_t, geoclue_exec_t)
 init_nnp_daemon_domain(geoclue_t)
 role system_r types geoclue_t;
 


### PR DESCRIPTION
Create geoclue_t domain with init_daemon_domain() interface instead of
application_domain() as it matches the "long running processes" condition
rather than "programs that are run interactively".

Resolves: rhbz# 1795524