### PR TITLE
Label all NetworkManager fortisslvpn plugins as openfortivpn_exec_t

### DIFF
--- a/openfortivpn.fc
+++ b/openfortivpn.fc
@@ -1,4 +1,4 @@
 /usr/bin/openfortivpn			--	gen_context(system_u:object_r:openfortivpn_exec_t,s0)
-/usr/libexec/nm-fortisslvpn-service	--	gen_context(system_u:object_r:openfortivpn_exec_t,s0)
+/usr/libexec/nm-fortisslvpn-.*	--	gen_context(system_u:object_r:openfortivpn_exec_t,s0)
 
 /var/lib/NetworkManager-fortisslvpn(/.*)?	gen_context(system_u:object_r:openfortivpn_var_lib_t,s0)


### PR DESCRIPTION
Label NetworkManager fortisslvpn plugin files matching
/usr/libexec/nm-fortisslvpn-.* regexp as openfortivpn_exec_t.

Resolves: rhbz#1803051