### PR TITLE
Update rkt policy to allow rkt_t domain to read sysfs filesystem

### DIFF
--- a/rkt.te
+++ b/rkt.te
@@ -34,6 +34,8 @@ kernel_read_net_sysctls(rkt_t)
 corenet_tcp_bind_generic_node(rkt_t)
 corenet_tcp_bind_rkt_port(rkt_t)
 
+dev_read_sysfs(rkt_t)
+
 domain_use_interactive_fds(rkt_t)
 
 sysnet_dns_name_resolve(rkt_t)


### PR DESCRIPTION
rkt_t domain need to read size of a transparent hugepage which found in hpage_pmd_size
to optimize memory allocation for rkt

Adding macro dev_read_sysfs(rkt_t) which allow to read files in sysfs_t domain

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1809000
Fedora COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1304792/