### PR TITLE
Allow targetd to exec lvm command

### DIFF
--- a/targetd.te
+++ b/targetd.te
@@ -5,6 +5,13 @@ policy_module(targetd, 1.0.0)
 # Declarations
 #
 
+require {
+    type lvm_t;
+    type lvm_var_run_t;
+    class file { getattr read write open lock };
+    class dbus send_msg;
+}
+
 type targetd_t;
 type targetd_exec_t;
 init_daemon_domain(targetd_t, targetd_exec_t)
@@ -23,6 +30,8 @@ files_tmp_file(targetd_tmp_t)
 # targetd local policy
 #
 
+
+
 allow targetd_t self:capability { ipc_lock sys_admin sys_nice };
 allow targetd_t self:fifo_file rw_fifo_file_perms;
 allow targetd_t self:unix_stream_socket create_stream_socket_perms;
@@ -30,6 +39,8 @@ allow targetd_t self:unix_dgram_socket create_socket_perms;
 allow targetd_t self:tcp_socket { accept listen };
 allow targetd_t self:netlink_route_socket r_netlink_socket_perms;
 allow targetd_t self:process { setfscreate setsched };
+allow targetd_t lvm_t:dbus send_msg;
+allow targetd_t lvm_var_run_t:file { getattr read write open lock };
 
 manage_dirs_pattern(targetd_t, targetd_etc_rw_t, targetd_etc_rw_t)
 manage_files_pattern(targetd_t, targetd_etc_rw_t, targetd_etc_rw_t)
@@ -93,6 +104,7 @@ optional_policy(`
    lvm_manage_lock(targetd_t)
    lvm_rw_pipes(targetd_t)
    lvm_stream_connect(targetd_t)
+   lvm_exec(targetd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Later versions of lvm removed the lvm2app API which targetd was
using.  Targetd has switched over to use libblockdev for its lvm
needs.  Thus targetd needs the ability to fork & exec lvm binary
which is what libblockdev does when using the lvm plugin.

Additionally the `lvm` command needs access to `/run/lvm/hints` and the ability to send dbus messages.