### PR TITLE
Add ibacm_t ipc_lock capability

### DIFF
--- a/ibacm.te
+++ b/ibacm.te
@@ -25,6 +25,7 @@ files_tmpfs_file(ibacm_tmpfs_t)
 #
 # ibacm local policy
 #
+allow ibacm_t self:capability ipc_lock;
 allow ibacm_t self:fifo_file rw_fifo_file_perms;
 allow ibacm_t self:unix_stream_socket create_stream_socket_perms;
 allow ibacm_t ibacm_t:netlink_rdma_socket { create_socket_perms };


### PR DESCRIPTION
Add ibacm_t the ipc_lock capability to support the update in kernel
to handle memory locking when interfacing with the Infiniband driver.