### PR TITLE
Update ninfod policy to add nnp transition from systemd to ninfod

### DIFF
--- a/ninfod.te
+++ b/ninfod.te
@@ -8,6 +8,7 @@ policy_module(ninfod, 1.0.0)
 type ninfod_t;
 type ninfod_exec_t;
 init_daemon_domain(ninfod_t, ninfod_exec_t)
+init_nnp_daemon_domain(ninfod_t)
 
 type ninfod_run_t;
 files_pid_file(ninfod_run_t)


### PR DESCRIPTION
Allow SELinux Domain trasition from systemd into confined domain with NoNewPrivileges
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1808987
Fedora COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1313518/