### PR TITLE
Update nscd_use() to mmap nscd runtime files unconditionally

### DIFF
--- a/nscd.if
+++ b/nscd.if
@@ -118,7 +118,6 @@ interface(`nscd_socket_use',`
 	stream_connect_pattern($1, nscd_var_run_t, nscd_var_run_t, nscd_t)
 	allow $1 nscd_t:unix_stream_socket { connectto create_socket_perms };
 	dontaudit $1 nscd_var_run_t:file read_file_perms;
-    allow $1 nscd_var_run_t:file map;
 	ps_process_pattern(nscd_t, $1)
 ')
 
@@ -133,6 +132,7 @@ interface(`nscd_socket_use',`
 ## </param>
 #
 interface(`nscd_use',`
+	allow $1 nscd_var_run_t:file map;
 	tunable_policy(`nscd_use_shm',`
 		nscd_shm_use($1)
 	',`


### PR DESCRIPTION
Move the rule to allow map nscd_var_run_t files from nscd_socket_use()
to nscd_use() so that it is allowed regardless of the nscd_use_shm
boolean. The nscd_var_run_t type is also used for nscd database files,
therefore the access has to be allowed when nscd uses shm as well.