### PR TITLE
Allow NetworkManager_ssh_t to execute_no_trans for binary ssh_exec_t

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -449,11 +449,11 @@ optional_policy(`
 
 optional_policy(`
     ssh_basic_client_template(NetworkManager, NetworkManager_t, system_r)
+    ssh_exec(NetworkManager_ssh_t)
     term_use_generic_ptys(NetworkManager_ssh_t)
     modutils_domtrans_kmod(NetworkManager_ssh_t)
     dbus_connect_system_bus(NetworkManager_ssh_t)
     dbus_system_bus_client(NetworkManager_ssh_t)
-
     networkmanager_dbus_chat(NetworkManager_ssh_t)
 ')
 


### PR DESCRIPTION
Add can_exec macro for NetworkManager_ssh_t domain, which allow to execute_no_trans for binary with label ssh_exec_t.
Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1813098