### PR TITLE
Allow ssh-keygen create file in /var/lib/glusterd

### DIFF
--- a/glusterd.te
+++ b/glusterd.te
@@ -332,3 +332,16 @@ optional_policy(`
 optional_policy(`
 	ssh_exec(glusterd_t)
 ')
+
+
+########################################
+#
+# Local policy for ssh_keygen
+#
+
+gen_require(`
+    type ssh_keygen_t;
+')
+
+manage_dirs_pattern(ssh_keygen_t, glusterd_var_lib_t, glusterd_var_lib_t)
+manage_files_pattern(ssh_keygen_t, glusterd_var_lib_t, glusterd_var_lib_t)


### PR DESCRIPTION
Gluster creates new ssh key pair in /var/lib/glusterd labeled as
glusterd_var_lib_t. Therefore ssh-keygen labeled as ssh_keygen_t needs to
have access to that directory.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1813917