### PR TITLE
Allow rngd create netlink_kobject_uevent_socket and read udev runtime…

### DIFF
--- a/rngd.te
+++ b/rngd.te
@@ -33,6 +33,7 @@ files_pid_file(rngd_var_run_t)
 allow rngd_t self:capability { ipc_lock sys_admin };
 allow rngd_t self:process { setsched signal };
 allow rngd_t self:fifo_file rw_fifo_file_perms;
+allow rngd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow rngd_t self:unix_stream_socket { accept listen };
 
 allow rngd_t rngd_var_run_t:file manage_file_perms;
@@ -63,3 +64,6 @@ optional_policy(`
 	pcscd_stream_connect(rngd_t)
 ')
 
+optional_policy(`
+	udev_read_pid_files(rngd_t)
+')


### PR DESCRIPTION
… files

The permissions are required when rtl-sdr is in place as the entropy source.
The librtlsdr library uses libusb, which uses libudev, which creates and
monitors a NETLINK_KOBJECT_UEVENT socket.

Resolves: rhbz#1818584