### PR TITLE
Allow ipa-adtrust-install restart sssd and dirsrv services

### DIFF
--- a/ipa.te
+++ b/ipa.te
@@ -222,6 +222,9 @@ auth_use_nsswitch(ipa_helper_t)
 
 files_list_tmp(ipa_helper_t)
 
+init_read_state(ipa_helper_t)
+init_stream_connect(ipa_helper_t)
+
 ipa_manage_pid_files(ipa_helper_t)
 ipa_read_lib(ipa_helper_t)
 
@@ -261,6 +264,11 @@ optional_policy(`
 
 optional_policy(`
     sssd_manage_lib_files(ipa_helper_t)
+    sssd_systemctl(ipa_helper_t)
+')
+
+optional_policy(`
+    systemd_config_generic_services(ipa_helper_t)
 ')
 
 ########################################


### PR DESCRIPTION
Allow ipa_helper_t connect to init using /run/systemd/private socket.
Allow ipa_helper_t read init process state.
Allow ipa_helper_t manage sssd and dirsrv units.