### PR TITLE
Update networkmanager_read_pid_files() to allow also list_dir_perms

### DIFF
--- a/networkmanager.if
+++ b/networkmanager.if
@@ -298,6 +298,7 @@ interface(`networkmanager_read_pid_files',`
 	')
 
 	files_search_pids($1)
+	list_dirs_pattern($1, NetworkManager_var_run_t, NetworkManager_var_run_t)
 	read_files_pattern($1, NetworkManager_var_run_t, NetworkManager_var_run_t)
 ')
 


### PR DESCRIPTION
Update the networkmanager_read_pid_files() interface so that the domain
allowed access can also list the NetworkManager runtime directory.