### PR TITLE
Allow nagios_plugin_domain execute programs in bin directories

### DIFF
--- a/nagios.te
+++ b/nagios.te
@@ -103,6 +103,8 @@ allow nagios_plugin_domain nagios_t:process signal_perms;
 dontaudit nagios_plugin_domain nrpe_t:tcp_socket { read write };
 dontaudit nagios_plugin_domain nagios_log_t:file { read write };
 
+corecmd_exec_bin(nagios_plugin_domain)
+
 dev_read_urand(nagios_plugin_domain)
 dev_read_rand(nagios_plugin_domain)
 dev_read_sysfs(nagios_plugin_domain)


### PR DESCRIPTION
Allow nagios_plugin_domain execute generic programs in system bin
directories without a domain transition.