### PR TITLE
Allow gluster geo-replication in rsync mode

### DIFF
--- a/glusterd.te
+++ b/glusterd.te
@@ -309,7 +309,7 @@ optional_policy(`
 
 optional_policy(`
 	rsync_exec(glusterd_t)
-	rsync_ioctl_stream_sockets(glusterd_t)
+	rsync_rw_unix_stream_sockets(glusterd_t)
 ')
 
 optional_policy(`

--- a/rsync.if
+++ b/rsync.if
@@ -175,6 +175,23 @@ interface(`rsync_read_data',`
 	read_files_pattern($1, rsync_data_t, rsync_data_t)
 ')
 
+########################################
+## <summary>
+##	Read and write rsync unix_stream_sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rsync_rw_unix_stream_sockets',`
+	gen_require(`
+		type rsync_t;
+	')
+
+	allow $1 rsync_t:unix_stream_socket rw_socket_perms;
+')
 
 ########################################
 ## <summary>


### PR DESCRIPTION
Add rsync_rw_unix_stream_sockets() interface.
Replace rsync_ioctl_stream_sockets() call for glusterd_t
to rsync_rw_unix_stream_sockets().