### PR TITLE
Add allow rules for lttng-sessiond domain

### DIFF
--- a/lttng-tools.te
+++ b/lttng-tools.te
@@ -28,7 +28,7 @@ allow lttng_sessiond_t self:capability2 block_suspend;
 allow lttng_sessiond_t self:process { setrlimit signal_perms };
 allow lttng_sessiond_t self:fifo_file rw_fifo_file_perms;
 allow lttng_sessiond_t self:tcp_socket listen;
-allow lttng_sessiond_t self:unix_stream_socket create_stream_socket_perms;
+allow lttng_sessiond_t self:unix_stream_socket { create_stream_socket_perms connectto };
 
 manage_dirs_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
 manage_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
@@ -36,6 +36,7 @@ manage_lnk_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessi
 manage_sock_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
 files_pid_filetrans(lttng_sessiond_t, lttng_sessiond_var_run_t, { dir })
 
+allow lttng_sessiond_t lttng_sessiond_tmpfs_t:file map;
 manage_dirs_pattern(lttng_sessiond_t, lttng_sessiond_tmpfs_t, lttng_sessiond_tmpfs_t)
 manage_files_pattern(lttng_sessiond_t, lttng_sessiond_tmpfs_t, lttng_sessiond_tmpfs_t)
 fs_tmpfs_filetrans(lttng_sessiond_t, lttng_sessiond_tmpfs_t, { dir file })
@@ -50,6 +51,7 @@ corenet_tcp_bind_generic_node(lttng_sessiond_t)
 corenet_tcp_bind_lltng_port(lttng_sessiond_t)
 
 dev_read_sysfs(lttng_sessiond_t)
+dev_read_rand(lttng_sessiond_t)
 
 fs_getattr_tmpfs(lttng_sessiond_t)
 
@@ -57,4 +59,5 @@ auth_use_nsswitch(lttng_sessiond_t)
 
 modutils_exec_kmod(lttng_sessiond_t)
 modutils_read_module_config(lttng_sessiond_t)
+modutils_read_module_deps_files(lttng_sessiond_t)
 files_read_kernel_modules(lttng_sessiond_t)


### PR DESCRIPTION
Allow lttng-sessiond domain to map files labeled lttng_sessiond_tmpfs_t,
to connect to unix stream sockets,
to read from random number generator devices
and to read the dependencies of kernel modules.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1808736