### PR TITLE
Label /var/run/sympa(/.*)? httpd_var_run_t

### DIFF
--- a/apache.fc
+++ b/apache.fc
@@ -180,6 +180,7 @@ ifdef(`distro_debian', `
 /var/run/nginx.*            gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/opt/rh/rh-nginx18/run/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/run/php-fpm(/.*)?      gen_context(system_u:object_r:httpd_var_run_t,s0)
+/var/run/sympa(/.*)?      gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/run/thttpd\.pid    -- gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/run/wsgi.*			-s	gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/run/user/apache(/.*)?		gen_context(system_u:object_r:httpd_tmp_t,s0)


### PR DESCRIPTION
As per https://github.com/sympa-community/sympa/issues/799

/var/run/sympa(/.*)? requires httpd_var_run_t SELinux label

This is for the mailing list manager "sympa" currently in Fedora and EPEL.