### PR TITLE
Allow nscd_socket_use() for domains in nscd_use() unconditionally

### DIFF
--- a/nscd.if
+++ b/nscd.if
@@ -133,10 +133,9 @@ interface(`nscd_socket_use',`
 ## </param>
 #
 interface(`nscd_use',`
+	nscd_socket_use($1)
 	tunable_policy(`nscd_use_shm',`
 		nscd_shm_use($1)
-	',`
-		nscd_socket_use($1)
 	')
 ')
 


### PR DESCRIPTION
The nscd_use() interface is used for nsswitch_domain or particular
domains to allow access to nscd services.
Each nscd database can be configured by the "shared" property in
nscd.conf to use the Shared memory or Socket mode.
Previously, either nscd_shm_use() or nscd_socket_use() were used,
depending on the value of the nscd_use_shm boolean.
Since this commit, nscd_socket_use() is always allowed so that in
different nscd databases different modes can be used.