### PR TITLE
Allow rhsmd read process state of all domains and kernel threads

### DIFF
--- a/rhsmcertd.te
+++ b/rhsmcertd.te
@@ -64,6 +64,7 @@ files_pid_filetrans(rhsmcertd_t, rhsmcertd_var_run_t, { file dir })
 
 kernel_read_network_state(rhsmcertd_t)
 kernel_read_net_sysctls(rhsmcertd_t)
+kernel_read_state(rhsmcertd_t)
 kernel_read_system_state(rhsmcertd_t)
 kernel_read_sysctl(rhsmcertd_t)
 kernel_signull(rhsmcertd_t)
@@ -83,6 +84,7 @@ dev_read_urand(rhsmcertd_t)
 dev_read_raw_memory(rhsmcertd_t)
 
 domain_obj_id_change_exemption(rhsmcertd_t)
+domain_read_all_domains_state(rhsmcertd_t)
 domain_signull_all_domains(rhsmcertd_t)
 
 files_list_tmp(rhsmcertd_t)


### PR DESCRIPTION
Allow rhsmcertd_t domain_read_all_domains_state() and kernel_read_state().
These permissions are required in newer versions of subscription-manager
that stopped using the psutil python library and implemented its own method
to read /proc.