### PR TITLE
Introduce logrotate_use_cifs boolean

### DIFF
--- a/logrotate.te
+++ b/logrotate.te
@@ -18,6 +18,13 @@ gen_tunable(logrotate_use_nfs, false)
 
 ## <desc>
 ## <p>
+## Allow logrotate to manage cifs files
+## </p>
+## </desc>
+gen_tunable(logrotate_use_cifs, false)
+
+## <desc>
+## <p>
 ## Allow logrotate domain to manage fuse files
 ## </p>
 ## </desc>
@@ -188,6 +195,12 @@ userdom_list_user_home_dirs(logrotate_t)
 userdom_use_unpriv_users_fds(logrotate_t)
 userdom_list_admin_dir(logrotate_t)
 userdom_dontaudit_getattr_user_home_content(logrotate_t)
+
+tunable_policy(`logrotate_use_cifs',`
+	fs_manage_cifs_files(logrotate_t)
+	fs_manage_cifs_dirs(logrotate_t)
+	fs_manage_cifs_symlinks(logrotate_t)
+')
 
 tunable_policy(`logrotate_use_nfs',`
         fs_manage_nfs_files(logrotate_t)


### PR DESCRIPTION
The logrotate_use_cifs boolean now can be used to allow logrotate
operate on CIFS volumes.