### PR TITLE
httpd: Allow NoNewPriv transition from systemd

### DIFF
--- a/apache.te
+++ b/apache.te
@@ -329,6 +329,7 @@ ifdef(`distro_redhat',`
 	typealias httpd_exec_t alias phpfpm_exec_t;
 ')
 init_daemon_domain(httpd_t, httpd_exec_t)
+init_nnp_daemon_domain(httpd_t)
 role system_r types httpd_t;
 
 # httpd_cache_t is the type given to the /var/cache/httpd


### PR DESCRIPTION
This enables running Apache/nginx directly under an unprivileged user
using systemd with the User/Group directives and optionnaly the
CAP_NET_BIND_SERVICE ambiant capability to bind <1024 ports.

See https://medium.com/@nickodell/sandboxing-nginx-with-systemd-80441923c555 for a recent example.

Tested as a module on Fedora 32.