### PR TITLE
Allow ptp4l_t sys_admin capability to run bpf programs

### DIFF
--- a/linuxptp.te
+++ b/linuxptp.te
@@ -154,7 +154,7 @@ allow ptp4l_t self:packet_socket create_socket_perms;
 allow ptp4l_t self:unix_stream_socket create_stream_socket_perms;
 allow ptp4l_t self:shm create_shm_perms;
 allow ptp4l_t self:udp_socket create_socket_perms;
-allow ptp4l_t self:capability { net_admin net_raw sys_time };
+allow ptp4l_t self:capability { net_admin net_raw sys_admin sys_time };
 allow ptp4l_t self:capability2 { wake_alarm };
 allow ptp4l_t self:netlink_route_socket rw_netlink_socket_perms;
 


### PR DESCRIPTION
In ptp4l, setsockopt() with SO_ATTACH_FILTER raises sk_attach_filter()
running a bpf program, for which the SYS_ADMIN capability is required.