### PR TITLE
Allow qemu-kvm read and write /dev/mapper/control

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -376,6 +376,10 @@ ps_process_pattern(svirt_tcg_t, virtd_t)
 
 virt_dontaudit_read_state(svirt_tcg_t)
 
+optional_policy(`
+	dev_rw_lvm_control(svirt_tcg_t)
+')
+
 ########################################
 #
 # virtd local policy


### PR DESCRIPTION
Allow svirt_tcg_t read and write to lvm_control_t char device.