### PR TITLE
Support multiple ways of tlp invocation

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -459,6 +459,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tlp_filetrans_named_content(NetworkManager_t)
+')
+
+optional_policy(`
 	udev_exec(NetworkManager_t)
 	udev_read_db(NetworkManager_t)
 	udev_read_pid_files(NetworkManager_t)

--- a/tlp.fc
+++ b/tlp.fc
@@ -1,4 +1,5 @@
 /usr/lib/systemd/system/((tlp-sleep.*)|(tlp.*))		--	gen_context(system_u:object_r:tlp_unit_file_t,s0)
+/usr/lib/systemd/system-sleep/tlp	--	gen_context(system_u:object_r:tlp_exec_t,s0)
 
 /usr/sbin/tlp		--	gen_context(system_u:object_r:tlp_exec_t,s0)
 

--- a/tlp.if
+++ b/tlp.if
@@ -39,6 +39,24 @@ interface(`tlp_exec',`
 	can_exec($1, tlp_exec_t)
 ')
 
+######################################
+## <summary>
+##	Transition to tlp named content
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tlp_filetrans_named_content',`
+	gen_require(`
+		type tlp_var_run_t;
+	')
+
+	files_pid_filetrans($1, tlp_var_run_t, dir, "tlp")
+')
+
 ########################################
 ## <summary>
 ##	Search tlp conf directories.


### PR DESCRIPTION
Label /usr/lib/systemd/system-sleep/tlp as tlp_exec_t.
Create the tlp_filetrans_named_content() interface for managing
the /run/tlp directory.
Allow NetworkManager_t tlp_filetrans_named_content().

Resolves: rhbz#1806123