### PR TITLE
stick together two lines /var/run/chrony.

### DIFF
--- a/chronyd.fc
+++ b/chronyd.fc
@@ -13,8 +13,7 @@
 
 /var/log/chrony(/.*)?	gen_context(system_u:object_r:chronyd_var_log_t,s0)
 
-/var/run/chrony(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
-/var/run/chronyd(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
+/var/run/chronyd?(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
 /var/run/chrony-helper(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
 /var/run/chronyd\.pid	--	gen_context(system_u:object_r:chronyd_var_run_t,s0)
 /var/run/chronyd\.sock	-s	gen_context(system_u:object_r:chronyd_var_run_t,s0)


### PR DESCRIPTION
Hi Dear contributors :-)
Just make it a little bit shorter without lost meaning.
I've just stuck it together. 
From 
```
/var/run/chrony(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
/var/run/chronyd(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
```
to
`/var/run/chronyd?(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)`
Thank you.

Signed-off-by: McSim85 <maxim@kramarenko.pro>