### PR TITLE
Remove files_mmap_usr_files() call for particular domains

### DIFF
--- a/aide.te
+++ b/aide.te
@@ -44,7 +44,6 @@ files_mmap_all_files(aide_t)
 files_read_all_symlinks(aide_t)
 files_getattr_all_pipes(aide_t)
 files_getattr_all_sockets(aide_t)
-files_mmap_usr_files(aide_t)
 
 mls_file_read_to_clearance(aide_t)
 mls_file_write_to_clearance(aide_t)

--- a/bind.te
+++ b/bind.te
@@ -163,7 +163,6 @@ dev_dontaudit_write_urand(named_t)
 domain_use_interactive_fds(named_t)
 
 files_read_etc_runtime_files(named_t)
-files_mmap_usr_files(named_t)
 
 fs_getattr_all_fs(named_t)
 fs_search_auto_mountpoints(named_t)

--- a/bitlbee.te
+++ b/bitlbee.te
@@ -123,8 +123,6 @@ auth_use_nsswitch(bitlbee_t)
 
 logging_send_syslog_msg(bitlbee_t)
 
-files_mmap_usr_files(bitlbee_t)
-
 optional_policy(`
     dbus_system_bus_client(bitlbee_t)
 ')

--- a/boltd.te
+++ b/boltd.te
@@ -42,7 +42,6 @@ dev_manage_sysfs(boltd_t)
 
 domain_read_all_domains_state(boltd_t)
 
-files_mmap_usr_files(boltd_t)
 fs_getattr_tmpfs(boltd_t)
 fs_getattr_xattr_fs(boltd_t)
 

--- a/cockpit.te
+++ b/cockpit.te
@@ -83,8 +83,6 @@ auth_use_nsswitch(cockpit_ws_t)
 
 corecmd_exec_bin(cockpit_ws_t)
 
-files_mmap_usr_files(cockpit_ws_t)
-
 fs_read_efivarfs_files(cockpit_ws_t)
 
 init_read_state(cockpit_ws_t)

--- a/dirsrv.te
+++ b/dirsrv.te
@@ -126,7 +126,6 @@ dev_read_sysfs(dirsrv_t)
 dev_read_urand(dirsrv_t)
 
 files_read_usr_symlinks(dirsrv_t)
-files_mmap_usr_files(dirsrv_t)
 
 fs_getattr_all_fs(dirsrv_t)
 fs_list_cgroup_dirs(dirsrv_t)

--- a/ipa.te
+++ b/ipa.te
@@ -104,8 +104,6 @@ corecmd_mmap_bin_files(ipa_custodia_t)
 
 domain_use_interactive_fds(ipa_custodia_t)
 
-files_mmap_usr_files(ipa_custodia_t)
-
 fs_getattr_xattr_fs(ipa_custodia_t)
 
 files_read_etc_files(ipa_custodia_t)

--- a/pdns.te
+++ b/pdns.te
@@ -62,8 +62,6 @@ auth_use_nsswitch(pdns_t)
 
 logging_send_syslog_msg(pdns_t)
 
-files_mmap_usr_files(pdns_t)
-
 
 ########################################
 #

--- a/pesign.te
+++ b/pesign.te
@@ -43,7 +43,6 @@ dev_read_urand(pesign_t)
 dev_read_rand(pesign_t)
 
 files_dontaudit_list_tmp(pesign_t)
-files_mmap_usr_files(pesign_t)
 
 fs_getattr_all_fs(pesign_t)
 

--- a/qpid.te
+++ b/qpid.te
@@ -78,7 +78,6 @@ dev_read_rand(qpidd_t)
 
 # needed by ssl
 files_list_tmp(qpidd_t)
-files_mmap_usr_files(qpidd_t)
 
 fs_getattr_all_fs(qpidd_t)
 


### PR DESCRIPTION
Remove all files_mmap_usr_files() calls in favor of the new, more
generic rule files_mmap_usr_files(domain). This applies to the
following types:

aide_t bitlbee_t boltd_t cockpit_ws_t dirsrv_t
ipa_custodia_t named_t pdns_t pesign_t qpidd_t

Related: https://github.com/fedora-selinux/selinux-policy/pull/371