### PR TITLE
Allow qemu read and write /dev/mapper/control

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -348,6 +348,8 @@ corenet_udp_bind_all_ports(svirt_t)
 corenet_tcp_bind_all_ports(svirt_t)
 corenet_tcp_connect_all_ports(svirt_t)
 
+dev_rw_lvm_control(svirt_t)
+
 init_dontaudit_read_state(svirt_t)
 
 virt_dontaudit_read_state(svirt_t)


### PR DESCRIPTION
Allow svirt_t read and write to the lvm_control_t char device.

Resolves: rhbz#1824019