### PR TITLE
Add sssd_access_kernel_keys tunable to conditionally access kernel keys

### DIFF
--- a/sssd.te
+++ b/sssd.te
@@ -6,6 +6,12 @@ policy_module(sssd, 1.2.0)
 #
 
 ## <desc>
+##	<p>
+##	Allow sssd read, view, and write access to kernel keys with kernel_t type
+##	</p>
+## </desc>
+gen_tunable(sssd_access_kernel_keys, false)
+
 ## <p>
 ##	Allow sssd connect to all unreserved ports
 ## </p>
@@ -153,6 +159,10 @@ userdom_manage_tmp_role(system_r, sssd_t)
 userdom_manage_all_users_keys(sssd_t)
 userdom_dbus_send_all_users(sssd_t)
 userdom_home_reader(sssd_t)
+
+tunable_policy(`sssd_access_kernel_keys',`
+	kernel_rw_key(sssd_t)
+')
 
 tunable_policy(`sssd_connect_all_unreserved_ports',`
 	corenet_tcp_connect_all_unreserved_ports(sssd_t)


### PR DESCRIPTION
Add sssd_access_kernel_keys tunable to allow read, view, and write
access to kernel keys with kernel_t type conditionally.