### PR TITLE
Create sssd_connect_all_unreserved_ports boolean

### DIFF
--- a/sssd.te
+++ b/sssd.te
@@ -5,6 +5,13 @@ policy_module(sssd, 1.2.0)
 # Declarations
 #
 
+## <desc>
+## <p>
+##	Allow sssd connect to all unreserved ports
+## </p>
+## </desc>
+gen_tunable(sssd_connect_all_unreserved_ports, false)
+
 type sssd_t;
 type sssd_exec_t;
 init_daemon_domain(sssd_t, sssd_exec_t)
@@ -146,6 +153,10 @@ userdom_manage_tmp_role(system_r, sssd_t)
 userdom_manage_all_users_keys(sssd_t)
 userdom_dbus_send_all_users(sssd_t)
 userdom_home_reader(sssd_t)
+
+tunable_policy(`sssd_connect_all_unreserved_ports',`
+	corenet_tcp_connect_all_unreserved_ports(sssd_t)
+')
 
 optional_policy(`
     bind_read_cache(sssd_t)


### PR DESCRIPTION
Create the sssd_connect_all_unreserved_ports boolean to allow sssd to connect
to all unreserved ports conditionally.