### PR TITLE
Make keepalived work with network namespaces

### DIFF
--- a/keepalived.fc
+++ b/keepalived.fc
@@ -4,4 +4,4 @@
 
 /usr/libexec/keepalived(/.*)?   gen_context(system_u:object_r:keepalived_unconfined_script_exec_t,s0)
 
-/var/run/keepalived.*		--	gen_context(system_u:object_r:keepalived_var_run_t,s0)
+/var/run/keepalived.*		gen_context(system_u:object_r:keepalived_var_run_t,s0)

--- a/keepalived.te
+++ b/keepalived.te
@@ -47,7 +47,8 @@ allow keepalived_t self:rawip_socket create_socket_perms;
 dontaudit keepalived_t self:capability sys_admin;
 
 manage_files_pattern(keepalived_t, keepalived_var_run_t, keepalived_var_run_t)
-files_pid_filetrans(keepalived_t, keepalived_var_run_t, { file })
+files_pid_filetrans(keepalived_t, keepalived_var_run_t, { dir file })
+allow keepalived_t keepalived_var_run_t:dir mounton;
 
 kernel_read_system_state(keepalived_t)
 kernel_read_network_state(keepalived_t)
@@ -74,6 +75,8 @@ domain_read_all_domains_state(keepalived_t)
 domain_getattr_all_domains(keepalived_t)
 
 dev_read_urand(keepalived_t)
+
+files_dontaudit_mounton_rootfs(keepalived_var_run_t)
 
 modutils_domtrans_kmod(keepalived_t)
 


### PR DESCRIPTION
Assign keepalived_var_run_t type also to directories in /run.
Allow keepalived_t mounton keepalived_var_run_t.