### PR TITLE
Allow irqbalance file transition for pid sock_files and directories

### DIFF
--- a/irqbalance.te
+++ b/irqbalance.te
@@ -26,8 +26,10 @@ dontaudit irqbalance_t self:capability sys_tty_config;
 allow irqbalance_t self:process { getcap getsched setcap signal_perms };
 allow irqbalance_t self:udp_socket create_socket_perms;
 
+manage_dirs_pattern(irqbalance_t, irqbalance_var_run_t, irqbalance_var_run_t)
 manage_files_pattern(irqbalance_t, irqbalance_var_run_t, irqbalance_var_run_t)
-files_pid_filetrans(irqbalance_t, irqbalance_var_run_t, file)
+manage_sock_files_pattern(irqbalance_t, irqbalance_var_run_t, irqbalance_var_run_t)
+files_pid_filetrans(irqbalance_t, irqbalance_var_run_t, { dir file sock_file })
 
 kernel_read_network_state(irqbalance_t)
 kernel_read_system_state(irqbalance_t)


### PR DESCRIPTION
Allow a file transition for irqbalance_t to its private type
in the runtime directory also for sock_file and directory classes.
Allow irqbalance_t manage directories and sock_files of its private type.

Resolves: rhbz#1852486