### PR TITLE
Update irqbalance runtime directory file context

### DIFF
--- a/irqbalance.fc
+++ b/irqbalance.fc
@@ -2,4 +2,4 @@
 
 /usr/sbin/irqbalance	--	gen_context(system_u:object_r:irqbalance_exec_t,s0)
 
-/var/run/irqbalance\.pid	--	gen_context(system_u:object_r:irqbalance_var_run_t,s0)
+/var/run/irqbalance.*		gen_context(system_u:object_r:irqbalance_var_run_t,s0)


### PR DESCRIPTION
Update file context specification for irqbalance in the runtime directory
so that it matches /var/run/irqbalance.* for all file types.

Resolves: rhbz#1852486