### PR TITLE
[WIP] Allow cupsd access local configuration files

### DIFF
--- a/cups.fc
+++ b/cups.fc
@@ -1,3 +1,5 @@
+HOME_DIR/\.cups(/.*)?		gen_context(system_u:object_r:cups_home_t,s0)
+/root/\.cups(/.*)?		gen_context(system_u:object_r:cups_home_t,s0)
 
 /etc/alchemist/namespace/printconf(/.*)? gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 

--- a/cups.if
+++ b/cups.if
@@ -447,3 +447,38 @@ interface(`cups_filetrans_named_content',`
 	corecmd_bin_filetrans($1, cupsd_rw_etc_t, dir, "inf")
 	files_var_filetrans($1, cupsd_rw_etc_t, dir, "cups")
 ')
+
+######################################
+## <summary>
+##  Transition to cups named admin home content
+## </summary>
+## <param name="domain">
+##  <summary>
+##      Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`cups_filetrans_admin_home_content',`
+    gen_require(`
+        type cups_home_t;
+    ')
+
+    userdom_admin_home_dir_filetrans($1, cups_home_t, dir, ".cups")
+')
+######################################
+## <summary>
+##  Transition to cups named home content
+## </summary>
+## <param name="domain">
+##  <summary>
+##      Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`cups_filetrans_home_content',`
+    gen_require(`
+        type cups_home_t;
+    ')
+
+    userdom_user_home_dir_filetrans($1, cups_home_t, dir, ".cups")
+')

--- a/cups.te
+++ b/cups.te
@@ -32,6 +32,9 @@ type cupsd_etc_t;
 typealias cupsd_etc_t alias hplip_etc_t;
 files_config_file(cupsd_etc_t)
 
+type cups_home_t;
+userdom_user_home_content(cups_home_t);
+
 type cupsd_initrc_exec_t;
 init_script_file(cupsd_initrc_exec_t)
 
@@ -149,6 +152,8 @@ allow cupsd_t cupsd_etc_t:dir manage_dir_perms;
 allow cupsd_t cupsd_etc_t:file { map rename setattr_file_perms };
 read_files_pattern(cupsd_t, cupsd_etc_t, cupsd_etc_t)
 read_lnk_files_pattern(cupsd_t, cupsd_etc_t, cupsd_etc_t)
+
+read_files_pattern(cupsd_t, cups_home_t, cups_home_t)
 
 manage_files_pattern(cupsd_t, cupsd_interface_t, cupsd_interface_t)
 can_exec(cupsd_t, cupsd_interface_t)


### PR DESCRIPTION
Label ~/.cups with cups_home_t.
Make cups_home_t usable in a user home directory.
Allow cupsd_t read files with the cups_home_t type.

Resolves: rhbz#1838495