### PR TITLE
Run ipa_helper_noatsecure(oddjob_t) only if the interface exists

### DIFF
--- a/oddjob.te
+++ b/oddjob.te
@@ -73,8 +73,10 @@ optional_policy(`
     init_dbus_chat(oddjob_t)
 ')
 
-optional_policy(`
-	ipa_helper_noatsecure(oddjob_t)
+ifdef(`ipa_helper_noatsecure',`
+	optional_policy(`
+		ipa_helper_noatsecure(oddjob_t)
+	')
 ')
 
 ########################################


### PR DESCRIPTION
The ipa_helper_noatsecure() interface is defined outside selinux-policy.
When referring to it for oddjob_t, using ipa_helper_noatsecure(oddjob_t),
it should be inside a conditional (ifdef) block.