### PR TITLE
virt: remove the libvirt qmf rules

### DIFF
--- a/virt.fc
+++ b/virt.fc
@@ -28,7 +28,6 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/libexec/libvirt_lxc --	gen_context(system_u:object_r:virtd_lxc_exec_t,s0)
 /usr/libexec/qemu-bridge-helper		gen_context(system_u:object_r:virt_bridgehelper_exec_t,s0)
 
-/usr/sbin/libvirt-qmf	--	gen_context(system_u:object_r:virt_qmf_exec_t,s0)
 /usr/sbin/libvirtd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtlockd --  gen_context(system_u:object_r:virtlogd_exec_t,s0)
 /usr/sbin/virtlogd --  gen_context(system_u:object_r:virtlogd_exec_t,s0)

--- a/virt.if
+++ b/virt.if
@@ -177,25 +177,6 @@ interface(`virt_exec',`
 
 ########################################
 ## <summary>
-##	Transition to virt_qmf.
-## </summary>
-## <param name="domain">
-## <summary>
-##	Domain allowed to transition.
-## </summary>
-## </param>
-#
-interface(`virt_domtrans_qmf',`
-	gen_require(`
-		type virt_qmf_t, virt_qmf_exec_t;
-	')
-
-	corecmd_search_bin($1)
-	domtrans_pattern($1, virt_qmf_exec_t, virt_qmf_t)
-')
-
-########################################
-## <summary>
 ##  Transition to virt_bridgehelper.
 ## </summary>
 ## <param name="domain">

--- a/virt.te
+++ b/virt.te
@@ -277,10 +277,6 @@ ifdef(`enable_mls',`
 	init_ranged_daemon_domain(virtlogd_t, virtlogd_exec_t, s0 - mls_systemhigh)
 ')
 
-type virt_qmf_t, virt_system_domain;
-type virt_qmf_exec_t, virt_file_type;
-init_daemon_domain(virt_qmf_t, virt_qmf_exec_t)
-
 type virt_bridgehelper_t, virt_system_domain;
 domain_type(virt_bridgehelper_t)
 
@@ -1651,42 +1647,6 @@ tunable_policy(`virt_sandbox_use_audit',`
 ')
 
 userdom_use_user_ptys(svirt_qemu_net_t)
-
-########################################
-#
-# virt_qmf local policy
-#
-allow virt_qmf_t self:capability { sys_nice sys_tty_config };
-allow virt_qmf_t self:process { setsched signal };
-allow virt_qmf_t self:fifo_file rw_fifo_file_perms;
-allow virt_qmf_t self:unix_stream_socket create_stream_socket_perms;
-allow virt_qmf_t self:tcp_socket create_stream_socket_perms;
-allow virt_qmf_t self:netlink_route_socket create_netlink_socket_perms;
-
-can_exec(virt_qmf_t, virtd_exec_t)
-
-kernel_read_system_state(virt_qmf_t)
-kernel_read_network_state(virt_qmf_t)
-
-dev_read_sysfs(virt_qmf_t)
-dev_read_rand(virt_qmf_t)
-dev_read_urand(virt_qmf_t)
-
-corenet_tcp_connect_matahari_port(virt_qmf_t)
-
-domain_use_interactive_fds(virt_qmf_t)
-
-logging_send_syslog_msg(virt_qmf_t)
-
-sysnet_read_config(virt_qmf_t)
-
-optional_policy(`
-	dbus_read_lib_files(virt_qmf_t)
-')
-
-optional_policy(`
-	virt_stream_connect(virt_qmf_t)
-')
 
 ########################################
 #


### PR DESCRIPTION
libvirt QMF is a project that has been dead upstream for about 9 years
and was retired after Fedora 16 and RHEL-6.

https://src.fedoraproject.org/rpms/libvirt-qmf/c/0db48fee9e03bbc4fa4e90205afc824ab9f1f37c

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>