### PR TITLE
Remove systemd_dbus_chat_resolved(pcp_pmie_t)

### DIFF
--- a/pcp.te
+++ b/pcp.te
@@ -293,7 +293,6 @@ logging_send_syslog_msg(pcp_pmie_t)
 systemd_exec_systemctl(pcp_pmie_t)
 systemd_read_unit_files(pcp_pmie_t)
 systemd_search_unit_dirs(pcp_pmie_t)
-systemd_dbus_chat_resolved(pcp_pmie_t)
 
 userdom_read_user_tmp_files(pcp_pmie_t)
 


### PR DESCRIPTION
The permissions are now allowed for the domain attribute.