### PR TITLE
Additional support for keepalived running in a namespace

### DIFF
--- a/keepalived.te
+++ b/keepalived.te
@@ -78,6 +78,8 @@ domain_getattr_all_domains(keepalived_t)
 dev_read_urand(keepalived_t)
 
 files_dontaudit_mounton_rootfs(keepalived_var_run_t)
+files_mounton_rootfs(keepalived_t)
+fs_unmount_tmpfs(keepalived_t)
 
 modutils_domtrans_kmod(keepalived_t)
 


### PR DESCRIPTION
Allow keepalived mount on the root filesystem.
Allow keepalived unmount a tmpfs filesystem.