### PR TITLE
Create macro in courier policy to allow to search dir and allow manage sock files and also use this macro in new boolean in apache

### DIFF
--- a/apache.te
+++ b/apache.te
@@ -181,6 +181,13 @@ gen_tunable(httpd_can_connect_ftp, false)
 
 ## <desc>
 ##  <p>
+##  Allow httpd to manage the courier spool sock files.  
+##  </p>
+## </desc>
+gen_tunable(httpd_can_manage_courier_spool, false)
+
+## <desc>
+##  <p>
 ##  Allow httpd to connect to the ldap port 
 ##  </p>
 ## </desc>
@@ -1430,8 +1437,14 @@ tunable_policy(`httpd_enable_cgi && httpd_unified',`
 	manage_lnk_files_pattern(httpd_sys_script_t, httpdcontent, httpdcontent)
 ')
 
+optional_policy(`
+	tunable_policy(`httpd_can_manage_courier_spool',`
+		courier_manage_spool_sockets(httpd_sys_script_t)
+	')
+')
+
 tunable_policy(`httpd_enable_homedirs && use_nfs_home_dirs',`
-        fs_list_auto_mountpoints(httpd_suexec_t)
+	fs_list_auto_mountpoints(httpd_suexec_t)
 	fs_read_nfs_files(httpd_suexec_t)
 	fs_read_nfs_symlinks(httpd_suexec_t)
 	fs_exec_nfs_files(httpd_suexec_t)

--- a/courier.if
+++ b/courier.if
@@ -162,6 +162,25 @@ interface(`courier_manage_spool_files',`
 
 ########################################
 ## <summary>
+##	Manage named socket in a courier spool directory.
+## </summary>
+## <param name="domains">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`courier_manage_spool_sockets',`
+	gen_require(`
+		type courier_spool_t;
+	')
+
+	files_search_spool($1)
+	manage_sock_files_pattern($1, courier_spool_t, courier_spool_t)
+')
+
+########################################
+## <summary>
 ##	Read courier spool files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
First commit:
Create interface, which for domain using this macro
allow to search dir and manage sock files in courier_spool_t domain

Second commit:
Create boolean which allow to httpd_sys_script_t,
where is store sqwebmail cgi binary file, to search dir and manage sock files
in courier_spool_t domain, which is domain for courier email files.
Also set this boolean to false by default.



Is related with issue on github : fedora-selinux/selinux-policy#290
