### PR TITLE
Revert "Dontaudit and disallow sys_admin capability for keepalived_t …

### DIFF
--- a/keepalived.te
+++ b/keepalived.te
@@ -34,7 +34,7 @@ files_tmp_file(keepalived_tmp_t)
 # keepalived local policy
 #
 
-allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_ptrace };
+allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_ptrace };
 allow keepalived_t self:process { signal_perms getpgid setpgid };
 allow keepalived_t self:netlink_socket create_socket_perms;
 allow keepalived_t self:netlink_generic_socket create_socket_perms;
@@ -43,8 +43,6 @@ allow keepalived_t self:netlink_connector_socket create_socket_perms;
 allow keepalived_t self:netlink_route_socket nlmsg_write;
 allow keepalived_t self:packet_socket create_socket_perms;
 allow keepalived_t self:rawip_socket create_socket_perms;
-
-dontaudit keepalived_t self:capability sys_admin;
 
 manage_dirs_pattern(keepalived_t, keepalived_var_run_t, keepalived_var_run_t)
 manage_files_pattern(keepalived_t, keepalived_var_run_t, keepalived_var_run_t)


### PR DESCRIPTION
…domain"

This reverts commit 18fb923d03cd36ee1c06bf6b32f0597a545fea18.
The sys_admin capability is required for the setns() and umount2()
syscalls which are used when namespaces in keepalived are in place.