### PR TITLE
Revert "Allow qemu-kvm read and write /dev/mapper/control"

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -374,10 +374,6 @@ ps_process_pattern(svirt_tcg_t, virtd_t)
 
 virt_dontaudit_read_state(svirt_tcg_t)
 
-optional_policy(`
-	dev_rw_lvm_control(svirt_tcg_t)
-')
-
 ########################################
 #
 # virtd local policy


### PR DESCRIPTION
This reverts commit 3d392c2732a208e5d7b2928816d7448194751511.
There seems to be a flaw in libvirt, likely a file descriptor leak.
The permission was added as a result of misunderstanding.