### PR TITLE
Revert "Allow qemu read and write /dev/mapper/control"

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -344,8 +344,6 @@ corenet_udp_bind_all_ports(svirt_t)
 corenet_tcp_bind_all_ports(svirt_t)
 corenet_tcp_connect_all_ports(svirt_t)
 
-dev_rw_lvm_control(svirt_t)
-
 init_dontaudit_read_state(svirt_t)
 
 virt_dontaudit_read_state(svirt_t)


### PR DESCRIPTION
This reverts commit 9ffe170e6d10b38f5ff7767a0b397f90baf42293.
There seems to be a flaw in libvirt, likely a file descriptor leak.
The permission was added as a result of misunderstanding.