### PR TITLE
Allow smbd get attributes of device files on samba_share_t

### DIFF
--- a/samba.te
+++ b/samba.te
@@ -317,6 +317,8 @@ manage_files_pattern(smbd_t, samba_share_t, samba_share_t)
 manage_fifo_files_pattern(smbd_t, samba_share_t, samba_share_t)
 manage_sock_files_pattern(smbd_t, samba_share_t, samba_share_t)
 manage_lnk_files_pattern(smbd_t, samba_share_t, samba_share_t)
+getattr_blk_files_pattern(smbd_t, samba_share_t, samba_share_t)
+getattr_chr_files_pattern(smbd_t, samba_share_t, samba_share_t)
 allow smbd_t samba_share_t:file { map };
 allow smbd_t samba_share_t:filesystem { getattr quotaget };
 


### PR DESCRIPTION
Allow smbd get attributes of character and block device files
on volumes labeled samba_share_t.