### PR TITLE
squid: Allow net_raw capability when squid_use_tproxy is enabled

### DIFF
--- a/squid.te
+++ b/squid.te
@@ -200,7 +200,7 @@ tunable_policy(`squid_connect_any',`
 ')
 
 tunable_policy(`squid_use_tproxy',`
-	allow squid_t self:capability net_admin;
+	allow squid_t self:capability { net_admin net_raw };
 	corenet_sendrecv_netport_server_packets(squid_t)
 	corenet_tcp_bind_netport_port(squid_t)
 	corenet_tcp_sendrecv_netport_port(squid_t)


### PR DESCRIPTION
When the SELinux boolean `squid_use_tproxy` is enabled, this module
allows Squid net_admin capabilities. However `net_raw` will be denied.
The capability however is needed when squid acts as a transparent proxy
in circumstances also outlined in the capabilites(7) man page:

    CAP_NET_RAW

       * Use RAW and PACKET sockets;
       * bind to any address for transparent proxying.

This patch adds `net_raw` to the capabilities which will be allowed if
`squid_use_tproxy` is enabled.