### PR TITLE
Allow qemu-ga read all non security file types conditionally

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -187,6 +187,13 @@ gen_tunable(virt_rw_qemu_ga_data, false)
 ## </desc>
 gen_tunable(virt_lockd_blk_devs, false)
 
+## <desc>
+## <p>
+## Allow qemu-ga read all non-security file types.
+## </p>
+## </desc>
+gen_tunable(virt_qemu_ga_read_nonsecurity_files, false)
+
 virt_domain_template(svirt)
 role system_r types svirt_t;
 typealias svirt_t alias qemu_t;
@@ -1752,6 +1759,10 @@ systemd_dbus_chat_logind(virt_qemu_ga_t)
 userdom_use_user_ptys(virt_qemu_ga_t)
 
 usermanage_domtrans_passwd(virt_qemu_ga_t)
+
+tunable_policy(`virt_qemu_ga_read_nonsecurity_files',`
+	files_read_non_security_files(virt_qemu_ga_t)
+')
 
 tunable_policy(`virt_read_qemu_ga_data',`
     read_files_pattern(virt_qemu_ga_t, virt_qemu_ga_data_t, virt_qemu_ga_data_t)


### PR DESCRIPTION
Create the virt_qemu_ga_read_nonsecurity_files boolean to conditionally
allow qemu guest agent read all directories, files, and symlinks of the
types which are a part of the non_security_file_type attribute.
This is required to do trim and freeze at any mountpoint.