### PR TITLE
Allow virtlockd only getattr and lock block devices

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -818,7 +818,7 @@ allow virtlogd_t virtd_t:lnk_file read_lnk_file_perms;
 virt_manage_lib_files(virtlogd_t)
 
 tunable_policy(`virt_lockd_blk_devs',`
-	read_blk_files_pattern(virtlogd_t, device_t, device_node)
+	dev_lock_all_blk_files(virtlogd_t)
 ')
 
 tunable_policy(`virt_use_nfs',`


### PR DESCRIPTION
Modify the virt_lockd_blk_devs boolean content so that
virtlockd is only allowed getattr and lock on block devices,
not the generic read pattern which conflicts a neverallow rule.