### PR TITLE
Label /usr/libexec/qemu-pr-helper with virtd_exec_t

### DIFF
--- a/virt.fc
+++ b/virt.fc
@@ -27,6 +27,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 
 /usr/libexec/libvirt_lxc --	gen_context(system_u:object_r:virtd_lxc_exec_t,s0)
 /usr/libexec/qemu-bridge-helper		gen_context(system_u:object_r:virt_bridgehelper_exec_t,s0)
+/usr/libexec/qemu-pr-helper	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 
 /usr/sbin/libvirtd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtlockd --  gen_context(system_u:object_r:virtlogd_exec_t,s0)


### PR DESCRIPTION
Label /usr/libexec/qemu-pr-helper with the virtd_exec_t type.
The file path has moved in qemu-kvm-5.0.0 so that now it matches
the /usr/libexec/qemu.* regexp and gets an incorrect type.