### PR TITLE
Add ipa_helper_noatsecure() interface unconditionally

### DIFF
--- a/ipa.if
+++ b/ipa.if
@@ -376,12 +376,10 @@ interface(`ipa_custodia_stream_connect',`
 ##	</summary>
 ## </param>
 #
-ifndef(`ipa_helper_noatsecure',`
-    interface(`ipa_helper_noatsecure',`
+interface(`ipa_helper_noatsecure',`
 	gen_require(`
 	    type ipa_helper_t;
         ')
 
         allow $1 ipa_helper_t:process { noatsecure };
-    ')
 ')


### PR DESCRIPTION
Using the #ifndef keyword seems to puzzle sepolgen-ifgen