### PR TITLE
The nfsdcld service is now confined by SELinux

### DIFF
--- a/rpc.fc
+++ b/rpc.fc
@@ -30,6 +30,7 @@
 /usr/sbin/rpc\.rquotad	--	gen_context(system_u:object_r:rpcd_exec_t,s0)
 /usr/sbin/rpc\.svcgssd	--	gen_context(system_u:object_r:gssd_exec_t,s0)
 /usr/sbin/sm-notify	--	gen_context(system_u:object_r:rpcd_exec_t,s0)
+/usr/sbin/nfsdcld	--	gen_context(system_u:object_r:rpcd_exec_t,s0)
 
 #
 # /var

--- a/rpc.te
+++ b/rpc.te
@@ -172,6 +172,7 @@ files_getattr_all_dirs(rpcd_t)
 
 fs_list_rpc(rpcd_t)
 fs_read_rpc_files(rpcd_t)
+fs_read_nfsd_files(rpcd_t)
 fs_read_rpc_symlinks(rpcd_t)
 fs_rw_rpc_sockets(rpcd_t)
 fs_get_all_fs_quotas(rpcd_t)


### PR DESCRIPTION
The nfsdcld service is confined by rpcd_t domain.
Allow rpcd_t domain to read files on an nfsd filesystem.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1834234