### PR TITLE
Allow plymouth sys_chroot capability

### DIFF
--- a/plymouthd.te
+++ b/plymouthd.te
@@ -31,7 +31,7 @@ files_pid_file(plymouthd_var_run_t)
 # Plymouthd private policy
 #
 
-allow plymouthd_t self:capability { sys_admin sys_tty_config };
+allow plymouthd_t self:capability { sys_admin sys_chroot sys_tty_config };
 allow plymouthd_t self:capability2 block_suspend;
 dontaudit plymouthd_t self:capability{ dac_read_search   };
 allow plymouthd_t self:process { signal getsched };


### PR DESCRIPTION
This capability is required as chroot() is called in the plymouth source code.