### PR TITLE
Targetd adds

### DIFF
--- a/rpc.if
+++ b/rpc.if
@@ -134,6 +134,24 @@ interface(`rpc_write_exports',`
 
 ########################################
 ## <summary>
+##	Manage nfs file exports
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rpc_manage_exports',`
+	gen_require(`
+		type exports_t;
+	')
+
+	manage_files_pattern($1, exports_t, exports_t)
+')
+
+########################################
+## <summary>
 ##	Execute domain in nfsd domain.
 ## </summary>
 ## <param name="domain">

--- a/targetd.te
+++ b/targetd.te
@@ -23,7 +23,7 @@ files_tmp_file(targetd_tmp_t)
 # targetd local policy
 #
 
-allow targetd_t self:capability { ipc_lock sys_admin sys_nice };
+allow targetd_t self:capability { chown ipc_lock sys_admin sys_nice };
 allow targetd_t self:fifo_file rw_fifo_file_perms;
 allow targetd_t self:unix_stream_socket create_stream_socket_perms;
 allow targetd_t self:unix_dgram_socket create_socket_perms;
@@ -40,6 +40,7 @@ manage_files_pattern(targetd_t, targetd_tmp_t, targetd_tmp_t)
 files_tmp_filetrans(targetd_t, targetd_tmp_t, { file dir })
 
 files_rw_isid_type_dirs(targetd_t)
+files_setattr_isid_type_dirs(targetd_t)
 
 fs_getattr_xattr_fs(targetd_t)
 fs_manage_configfs_files(targetd_t)
@@ -55,7 +56,7 @@ kernel_load_module(targetd_t)
 kernel_request_load_module(targetd_t)
 kernel_dgram_send(targetd_t)
 
-rpc_read_exports(targetd_t)
+rpc_manage_exports(targetd_t)
 
 storage_raw_rw_fixed_disk(targetd_t)
 
@@ -86,13 +87,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-   lvm_read_config(targetd_t)
-   lvm_map_config(targetd_t)
-   lvm_write_metadata(targetd_t)
-   lvm_manage_metadata(targetd_t)
-   lvm_manage_lock(targetd_t)
-   lvm_rw_pipes(targetd_t)
-   lvm_stream_connect(targetd_t)
+    lvm_domtrans(targetd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Later versions of lvm removed the lvm2app API which targetd was
using.  Target has switched over to use libblockdev for its lvm
needs.  Thus targetd needs the ability to fork & exec lvm binary
which is what libblockdev does when using the lvm plugin.  Also
we need the ability to update the lvm hints file and talk to the lvm
dbus service.

Additional allows found by running new unit test.

see: https://github.com/fedora-selinux/selinux-policy/pull/431 for
added interfaces to lvm which this change is using.
