### PR TITLE
Allow cups_pdf_t domain to communicate with unix_dgram_socket

### DIFF
--- a/cups.te
+++ b/cups.te
@@ -614,6 +614,7 @@ optional_policy(`
 #
 
 allow cups_pdf_t self:capability { chown fowner fsetid setuid setgid dac_read_search dac_override };
+allow cups_pdf_t self:unix_dgram_socket create_stream_socket_perms;
 allow cups_pdf_t self:unix_stream_socket create_stream_socket_perms;
 allow cups_pdf_t cupsd_rw_etc_t:dir search;
 


### PR DESCRIPTION
Allow cups_pdf_t domain to communicate with processes labeled cups_pdf_t on same machine using unix_dgram_socket.
The cups-pdf service had allowed communication with unix_stream_socket but now the service starts to use another type of socket.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1832521