### PR TITLE
rpc.fc: Include /etc/exports.d dir & files

### DIFF
--- a/rpc.fc
+++ b/rpc.fc
@@ -4,6 +4,7 @@
 # /etc
 #
 /etc/exports		--	gen_context(system_u:object_r:exports_t,s0)
+/etc/exports\.d(/.*)?		gen_context(system_u:object_r:exports_t,s0)
 /etc/rc\.d/init\.d/nfs	 --	gen_context(system_u:object_r:nfsd_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/nfslock --	gen_context(system_u:object_r:rpcd_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/rpcidmapd --	gen_context(system_u:object_r:rpcd_initrc_exec_t,s0)


### PR DESCRIPTION
The directory /etc/exports.d and files which reside in it should
have the exports_t context.
    
see: man 5 exports
    
Signed-off-by: Tony Asleson <tasleson@redhat.com>