### PR TITLE
Add default file context for /usr/libexec/pcp/lib/*

### DIFF
--- a/pcp.fc
+++ b/pcp.fc
@@ -20,6 +20,11 @@
 /usr/libexec/pcp/bin/pmie     --      gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
 /usr/libexec/pcp/bin/pmmgr  --      gen_context(system_u:object_r:pcp_pmmgr_exec_t,s0)
 
+/usr/libexec/pcp/lib/pmcd	--	gen_context(system_u:object_r:pcp_pmcd_exec_t,s0)
+/usr/libexec/pcp/lib/pmlogger	--	gen_context(system_u:object_r:pcp_pmlogger_exec_t,s0)
+/usr/libexec/pcp/lib/pmproxy	--	gen_context(system_u:object_r:pcp_pmproxy_exec_t,s0)
+/usr/libexec/pcp/lib/pmie	--	gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
+
 /usr/share/pcp/lib/pmie     --      gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
 
 /usr/share/pcp/lib/pmlogger   --      gen_context(system_u:object_r:pcp_pmlogger_exec_t,s0)


### PR DESCRIPTION
As a result of changes in pcp systemd units, some executables were moved
to /usr/libexec/pcp/lib. The default file context specification in the
selinux policy needs to be adjusted accordingly.