### PR TITLE
Allow slapd manage files/dirs in ldap certificates directory

### DIFF
--- a/ldap.te
+++ b/ldap.te
@@ -57,8 +57,8 @@ allow slapd_t self:process { setsched signal } ;
 allow slapd_t self:fifo_file rw_fifo_file_perms;
 allow slapd_t self:tcp_socket { accept listen };
 
-add_entry_dirs_pattern(slapd_t, slapd_cert_t, slapd_cert_t)
-read_files_pattern(slapd_t, slapd_cert_t, slapd_cert_t)
+manage_dirs_pattern(slapd_t, slapd_cert_t, slapd_cert_t)
+manage_files_pattern(slapd_t, slapd_cert_t, slapd_cert_t)
 read_lnk_files_pattern(slapd_t, slapd_cert_t, slapd_cert_t)
 
 manage_dirs_pattern(slapd_t, slapd_db_t, slapd_db_t)


### PR DESCRIPTION
Allow slapd manage files and directories in the ldap certificates
directory. This change is needed because of recent changes in the nss
library.