### PR TITLE
Revert "Allow certmonger add new entries in a generic certificates di…

### DIFF
--- a/certmonger.te
+++ b/certmonger.te
@@ -101,7 +101,6 @@ libs_exec_ldconfig(certmonger_t)
 
 logging_send_syslog_msg(certmonger_t)
 
-miscfiles_add_entry_generic_cert_dirs(certmonger_t)
 miscfiles_manage_all_certs(certmonger_t)
 
 systemd_exec_systemctl(certmonger_t)


### PR DESCRIPTION
…rectory"

This reverts commit a4d15a45bbadc82a2cfac84336e559725d079b01.
Request for managing certificates directories was resolved
by the miscfiles_manage_all_certs() interface update.