### PR TITLE
Set correct default file context for /usr/libexec/pcp/lib/*

### DIFF
--- a/pcp.fc
+++ b/pcp.fc
@@ -14,10 +14,10 @@
 /usr/libexec/pcp/bin/pmproxy    --      gen_context(system_u:object_r:pcp_pmproxy_exec_t,s0)
 /usr/libexec/pcp/bin/pmie     --      gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
 
-/usr/libexec/pcp/lib/pmcd	--	gen_context(system_u:object_r:pcp_pmcd_exec_t,s0)
-/usr/libexec/pcp/lib/pmlogger	--	gen_context(system_u:object_r:pcp_pmlogger_exec_t,s0)
-/usr/libexec/pcp/lib/pmproxy	--	gen_context(system_u:object_r:pcp_pmproxy_exec_t,s0)
-/usr/libexec/pcp/lib/pmie	--	gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
+/usr/libexec/pcp/lib/pmcd	--	gen_context(system_u:object_r:pcp_pmcd_initrc_exec_t,s0)
+/usr/libexec/pcp/lib/pmlogger	--	gen_context(system_u:object_r:pcp_pmlogger_initrc_exec_t,s0)
+/usr/libexec/pcp/lib/pmproxy	--	gen_context(system_u:object_r:pcp_pmproxy_initrc_exec_t,s0)
+/usr/libexec/pcp/lib/pmie	--	gen_context(system_u:object_r:pcp_pmie_initrc_exec_t,s0)
 
 /usr/share/pcp/lib/pmie     --      gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
 


### PR DESCRIPTION
As a result of changes in pcp systemd units, start scripts were moved
from /etc/rc.d/init.d to /usr/libexec/pcp/lib. The default file context
specification in the selinux policy needs to be adjusted accordingly.

The previous commit c0d525029caa7c5275f530dce8a003a800cad619 specified
the type improperly.