### PR TITLE
Allow for confined users acces to wtmp

### DIFF
--- a/screen.if
+++ b/screen.if
@@ -81,8 +81,11 @@ template(`screen_role_template',`
 	corecmd_shell_domtrans($1_screen_t, $3)
 	corecmd_bin_domtrans($1_screen_t, $3)
 
+	application_exec($1_screen_t)
+
 	auth_domtrans_chk_passwd($1_screen_t)
 	auth_use_nsswitch($1_screen_t)
+	auth_rw_login_records($1_screen_t)
 
 	logging_send_syslog_msg($1_screen_t)
 


### PR DESCRIPTION
Allow for confined users screen acess to wtmp, via interface
application_exec() and auth_rw_login_records().
Macro application_exec() allow execute application
executables in the caller domain.
Interface auth_rw_login_records() allow read
and write login records.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1767745
Fedora COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1728304/