### PR TITLE
Introduce rpmdb_t type

### DIFF
--- a/rpm.fc
+++ b/rpm.fc
@@ -8,6 +8,7 @@
 /usr/bin/dnf-automatic  --  gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/bin/dnf-[0-9]+		--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/bin/rpm 			--	gen_context(system_u:object_r:rpm_exec_t,s0)
+/usr/bin/rpmdb 			--	gen_context(system_u:object_r:rpmdb_exec_t,s0)
 /usr/bin/smart 			--	gen_context(system_u:object_r:rpm_exec_t,s0)
 
 /bin/yum-builddep		--	gen_context(system_u:object_r:rpm_exec_t,s0)

--- a/rpm.if
+++ b/rpm.if
@@ -115,6 +115,50 @@ interface(`rpm_exec',`
 
 ########################################
 ## <summary>
+##	Execute rpmdb in the rpmdb domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`rpmdb_domtrans_rpmdb',`
+	gen_require(`
+		type rpmdb_t, rpmdb_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rpmdb_exec_t, rpmdb_t)
+')
+
+########################################
+## <summary>
+##	Execute rpmdb in the rpmdb domain,
+##	and allow the specified role the rpmdb domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+#
+interface(`rpmdb_run_rpmdb',`
+	gen_require(`
+		attribute_role rpmdb_roles;
+	')
+
+	rpmdb_domtrans_rpmdb($1)
+	roleattribute $2 rpmdb_roles;
+')
+
+########################################
+## <summary>
 ##	Do not audit to execute a rpm.
 ## </summary>
 ## <param name="domain">

--- a/rpm.te
+++ b/rpm.te
@@ -3,6 +3,8 @@ policy_module(rpm, 1.16.0)
 attribute rpm_transition_domain;
 attribute_role rpm_script_roles;
 roleattribute system_r rpm_script_roles;
+attribute_role rpmdb_roles;
+roleattribute system_r rpmdb_roles;
 
 ########################################
 #
@@ -16,6 +18,11 @@ domain_role_change_exemption(rpm_t)
 domain_system_change_exemption(rpm_t)
 domain_interactive_fd(rpm_t)
 role rpm_script_roles types rpm_t;
+
+type rpmdb_t;
+type rpmdb_exec_t;
+init_system_domain(rpmdb_t, rpmdb_exec_t)
+role rpmdb_roles types rpmdb_t;
 
 type debuginfo_exec_t;
 domain_entry_file(rpm_t, debuginfo_exec_t)
@@ -41,6 +48,9 @@ files_type(rpm_var_cache_t)
 
 type rpm_var_run_t;
 files_pid_file(rpm_var_run_t)
+
+type rpmdb_tmp_t;
+files_tmp_file(rpmdb_tmp_t)
 
 type rpm_script_t;
 type rpm_script_exec_t;
@@ -249,6 +259,28 @@ optional_policy(`
 	unconfined_dbus_chat(rpm_t)
 	unconfined_dbus_chat(rpm_script_t)
 ')
+
+########################################
+#
+# rpmdb local policy
+#
+
+allow rpmdb_t rpm_var_lib_t:file map;
+allow rpmdb_t rpmdb_tmp_t:file map;
+
+manage_dirs_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
+manage_files_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
+files_var_lib_filetrans(rpmdb_t, rpm_var_lib_t, dir)
+
+manage_dirs_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
+manage_files_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
+files_tmp_filetrans(rpmdb_t, rpmdb_tmp_t, { file dir })
+
+auth_dontaudit_read_passwd(rpmdb_t)
+
+files_rw_inherited_non_security_files(rpmdb_t)
+
+sysnet_dontaudit_read_config(rpmdb_t)
 
 ########################################
 #


### PR DESCRIPTION
When a rpm database is rebuilt using the rpmdb command, a temporary
directory in /var/lib is created to be renamed to rpm later.
This requires rpmdb run in a private domain so that an unnamed
transition can be defined.

This commit adds rpmdb_t and rpmdb_exec_t types,
rpm_domtrans_rpmdb() and rpm_run_rpmdb() interfaces.
Additionally, read/write access to non-security files is allowed to
provide a way for rpmdb to use files when stdin or stdout is expected.

Resolves: rhbz#1461313