### PR TITLE
Change fetchmail temporary files path to /var/spool/mail

### DIFF
--- a/fetchmail.fc
+++ b/fetchmail.fc
@@ -11,7 +11,7 @@ HOME_DIR/\.fetchmailrc	--	gen_context(system_u:object_r:fetchmail_home_t,s0)
 
 /var/log/fetchmail.*	gen_context(system_u:object_r:fetchmail_log_t,s0)
 
-/var/mail/\.fetchmail-UIDL-cache	--	gen_context(system_u:object_r:fetchmail_uidl_cache_t,s0)
-/var/mail/\.fetchmail\.pid	--	gen_context(system_u:object_r:fetchmail_uidl_cache_t,s0)
-
 /var/run/fetchmail.*	gen_context(system_u:object_r:fetchmail_var_run_t,s0)
+
+/var/spool/mail/\.fetchmail-UIDL-cache	--	gen_context(system_u:object_r:fetchmail_uidl_cache_t,s0)
+/var/spool/mail/\.fetchmail\.pid	--	gen_context(system_u:object_r:fetchmail_uidl_cache_t,s0)


### PR DESCRIPTION
Until now, the .fetchmail-UIDL-cache and .fetchmail.pid files had
default file context defined for the /var/mail path, in Fedora though
/var/mail is a symlink to spool/mail, so the path actually needs to be
/var/spool/mail.

Resolves: rhbz#1840880