### PR TITLE
Allow dnsmasq read public files

### DIFF
--- a/dnsmasq.te
+++ b/dnsmasq.te
@@ -112,6 +112,8 @@ libs_exec_ldconfig(dnsmasq_t)
 
 logging_send_syslog_msg(dnsmasq_t)
 
+miscfiles_read_public_files(dnsmasq_t)
+
 userdom_dontaudit_use_unpriv_user_fds(dnsmasq_t)
 userdom_dontaudit_search_user_home_dirs(dnsmasq_t)
 


### PR DESCRIPTION
As a part of dnsmasq code, there is also an implementation of a tftp
server. Read access to public content files used for file transfer
services is required for dnsmasq to be able to provide the tftp service.

Resolves: rhbz#1782539