### PR TITLE
Allow rpmdb rw access to inherited console, ttys, and ptys

### DIFF
--- a/rpm.te
+++ b/rpm.te
@@ -276,6 +276,8 @@ manage_dirs_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
 manage_files_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
 files_tmp_filetrans(rpmdb_t, rpmdb_tmp_t, { file dir })
 
+term_use_all_inherited_terms(rpmdb_t)
+
 auth_dontaudit_read_passwd(rpmdb_t)
 
 files_rw_inherited_non_security_files(rpmdb_t)


### PR DESCRIPTION
With introducing the rpmdb_t private type, rpmdb also needs read and write
inherited console, all tty, and all pty terminals to be able to display
messages, e. g. when --help switch is used.

Resolves: rhbz#1899548