### PR TITLE
Allow kexec manage generic tmp files

### DIFF
--- a/kdump.te
+++ b/kdump.te
@@ -56,6 +56,7 @@ manage_files_pattern(kdump_t, kdump_lock_t, kdump_lock_t)
 manage_lnk_files_pattern(kdump_t, kdump_lock_t, kdump_lock_t)
 files_lock_filetrans(kdump_t, kdump_lock_t, { dir file lnk_file })
 
+files_manage_generic_tmp_files(kdump_t)
 files_read_etc_runtime_files(kdump_t)
 files_read_kernel_symbol_table(kdump_t)
 files_read_kernel_modules(kdump_t)


### PR DESCRIPTION
This permission is required on aarch64 architecture when a temporary
file is created by kexec.