### PR TITLE
Allow sssd read /run/systemd directory

### DIFF
--- a/sssd.te
+++ b/sssd.te
@@ -129,6 +129,8 @@ auth_manage_cache(sssd_t)
 auth_login_manage_key(sssd_t)
 dontaudit sssd_t init_t:dbus send_msg;
 
+# sssd uses inotify to watch for changes in /run/systemd/resolve
+init_list_pid_dirs(sssd_t)
 init_read_utmp(sssd_t)
 
 logging_send_syslog_msg(sssd_t)


### PR DESCRIPTION
The nsswitch_domain is already allowed search /run/systemd, sssd however
requires the read permission, granted by the list_dir_perms pattern.

The reason is that sssd is using an asynchronous resolver library
(c-ares) and monitors /etc/resolv.conf for changes. If /etc/resolv.conf
is replaced with a symlink, SSSD tries to follow it to set an inotify
watch to be aware of the target file changes. The resolv.conf file
changes can be made by a user, NetworkManager, or systemd-resolved.

Resolves: rhbz#1827466