### PR TITLE
Allow IPsec and Certmonger to use opencryptoki services

### DIFF
--- a/certmonger.te
+++ b/certmonger.te
@@ -171,7 +171,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    pkcs_read_lock(certmonger_t)
+    pkcs_use_opencryptoki(certmonger_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Add to certmonger and ipsec policy interface pkcs_use_opencryptoki(),
which allow use opencryptoki. Opencryptoki implements PKCS#11
standard.

Resolves: rhbz#1952311