### PR TITLE
Add permissions to delete lnk_files into gnome_delete_home_config()

### DIFF
--- a/gnome.if
+++ b/gnome.if
@@ -1307,6 +1307,7 @@ interface(`gnome_delete_home_config',`
     ')
 
     delete_files_pattern($1, config_home_t, config_home_t)
+    delete_lnk_files_pattern($1, config_home_t, config_home_t)
 ')
 
 ########################################


### PR DESCRIPTION
The gnome_delete_home_config() interface contains delete_files_pattern()
call for config_home_t files only, but symlinks can be there, too.

Resolves: rhbz#1909344