### PR TITLE
Label /var/lib/kdump with kdump_var_lib_t

### DIFF
--- a/kdump.fc
+++ b/kdump.fc
@@ -13,4 +13,6 @@
 
 /var/crash(/.*)?		gen_context(system_u:object_r:kdump_crash_t,s0)
 
+/var/lib/kdump(/.*)?		gen_context(system_u:object_r:kdump_var_lib_t,s0)
+
 /var/lock/kdump(/.*)?   gen_context(system_u:object_r:kdump_lock_t,s0)

--- a/kdump.if
+++ b/kdump.if
@@ -322,3 +322,22 @@ interface(`kdump_dontaudit_inherited_kdumpctl_tmp_pipes',`
         dontaudit $1 kdumpctl_tmp_t:fifo_file rw_inherited_fifo_file_perms;
 ')
 
+
+###################################
+## <summary>
+##     Manage kdump lib files
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain to allow access
+##      </summary>
+## </param>
+#
+interface(`kdump_manage_lib_files',`
+        gen_require(`
+                type kdump_var_lib_t;
+        ')
+
+	manage_files_pattern($1, kdump_var_lib_t, kdump_var_lib_t)
+')
+

--- a/kdump.te
+++ b/kdump.te
@@ -16,6 +16,9 @@ files_config_file(kdump_etc_t)
 type kdump_crash_t;
 files_type(kdump_crash_t)
 
+type kdump_var_lib_t;
+files_type(kdump_var_lib_t)
+
 type kdump_initrc_exec_t;
 init_script_file(kdump_initrc_exec_t)
 
@@ -48,6 +51,8 @@ manage_dirs_pattern(kdump_t, kdump_crash_t, kdump_crash_t)
 manage_files_pattern(kdump_t, kdump_crash_t, kdump_crash_t)
 manage_lnk_files_pattern(kdump_t, kdump_crash_t, kdump_crash_t)
 files_var_filetrans(kdump_t, kdump_crash_t, dir, "crash")
+
+manage_files_pattern(kdump_t, kdump_var_lib_t, kdump_var_lib_t)
 
 read_files_pattern(kdump_t, kdump_etc_t, kdump_etc_t)
 

--- a/rpm.te
+++ b/rpm.te
@@ -465,6 +465,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kdump_manage_lib_files(rpm_script_t)
+')
+
+optional_policy(`
 	lvm_domtrans(rpm_script_t, rpm_script_roles)
 ')
 


### PR DESCRIPTION
The kexec-tools usually create initramfs-KERNELVERSIONkdump.img in /boot.
On some operating systems, the /boot directory can be read-only,
preventing the image file from being created. In newer kexec-tools
package versions, the image files are created in /var/lib/kdump
in case /boot is read-only.

The kdump_manage_lib_files() interface was created and rpm_script_t
allowed to manage /var/lib/kdump files. This is needed when the
/lib/kernel/install.d/60-kdump.install kernel install hook is triggered
to delete unused images.

Resolves: rhbz#1951323